### PR TITLE
Set catalog mode to strict

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,8 @@ packages:
   - apps/*
   - packages/*
 
+catalogMode: strict
+
 catalog:
   react: 19.2.0
   react-dom: 19.2.0


### PR DESCRIPTION
pnpm の catalog mode を strict に設定することで、
カタログに定義されていないバージョンの依存関係を使用できないように制限します。
これにより、プロジェクト全体でのバージョン管理の一貫性を強制できます。