### PR TITLE
顧客リストページ実装

### DIFF
--- a/apps/web/app/customers/customer-search-form.tsx
+++ b/apps/web/app/customers/customer-search-form.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { Button } from "@workspace/ui/components/button";
+import { Input } from "@workspace/ui/components/input";
+import { Search } from "lucide-react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
+
+export function CustomerSearchForm() {
+	const router = useRouter();
+	const searchParams = useSearchParams();
+	const [keyword, setKeyword] = useState(searchParams.get("keyword") || "");
+
+	function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+		e.preventDefault();
+		const params = new URLSearchParams(searchParams);
+
+		if (keyword.trim()) {
+			params.set("keyword", keyword.trim());
+		} else {
+			params.delete("keyword");
+		}
+
+		// Reset to page 1 when searching
+		params.delete("page");
+
+		router.push(`/customers?${params.toString()}`);
+	}
+
+	function handleClear() {
+		setKeyword("");
+		const params = new URLSearchParams(searchParams);
+		params.delete("keyword");
+		params.delete("page");
+		router.push(`/customers?${params.toString()}`);
+	}
+
+	return (
+		<form className="flex gap-2" onSubmit={handleSubmit}>
+			<div className="relative flex-1 max-w-md">
+				<Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
+				<Input
+					className="pl-9"
+					onChange={(e) => setKeyword(e.target.value)}
+					placeholder="名前またはメールアドレスで検索"
+					type="text"
+					value={keyword}
+				/>
+			</div>
+			<Button type="submit">検索</Button>
+			{keyword && (
+				<Button onClick={handleClear} type="button" variant="outline">
+					クリア
+				</Button>
+			)}
+		</form>
+	);
+}

--- a/apps/web/app/customers/customers-container.tsx
+++ b/apps/web/app/customers/customers-container.tsx
@@ -1,0 +1,40 @@
+import { createClient } from "@repo/supabase/nextjs/server";
+import { cacheTag } from "next/cache";
+import { redirect } from "next/navigation";
+import { getCustomers } from "../../features/customer/get-customers";
+import { CustomersPresenter } from "./customers-presenter";
+
+export const TAG_CUSTOMER = "customer";
+
+type CustomersContainerProps = {
+	keyword?: string;
+	page?: string;
+};
+
+export async function CustomersContainer({
+	keyword,
+	page,
+}: CustomersContainerProps) {
+	"use cache: remote";
+	cacheTag(TAG_CUSTOMER);
+
+	// Authentication check
+	const supabase = await createClient();
+	const {
+		data: { user },
+	} = await supabase.auth.getUser();
+
+	if (!user) {
+		redirect("/login");
+	}
+
+	// Fetch customers data
+	const pageNumber = page ? Number.parseInt(page, 10) : 1;
+	const data = await getCustomers({
+		keyword,
+		page: pageNumber,
+		pageSize: 20,
+	});
+
+	return <CustomersPresenter data={data} keyword={keyword} />;
+}

--- a/apps/web/app/customers/customers-presenter.tsx
+++ b/apps/web/app/customers/customers-presenter.tsx
@@ -1,0 +1,126 @@
+import { Button } from "@workspace/ui/components/button";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@workspace/ui/components/table";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import Link from "next/link";
+import type { GetCustomersResult } from "../../features/customer/get-customers";
+
+type CustomersPresenterProps = {
+	data: GetCustomersResult;
+	keyword?: string;
+};
+
+export function CustomersPresenter({ data, keyword }: CustomersPresenterProps) {
+	const { customers, page, totalPages, total } = data;
+
+	return (
+		<div className="space-y-4">
+			{/* Results summary */}
+			<div className="text-sm text-muted-foreground">
+				{keyword && <span>「{keyword}」の検索結果: </span>}
+				{total}件
+			</div>
+
+			{/* Table */}
+			<div className="rounded-md border">
+				<Table>
+					<TableHeader>
+						<TableRow>
+							<TableHead className="w-[300px]">名前</TableHead>
+							<TableHead>メールアドレス</TableHead>
+							<TableHead className="w-[180px]">登録日</TableHead>
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{customers.length === 0 ? (
+							<TableRow>
+								<TableCell className="text-center py-8" colSpan={3}>
+									{keyword
+										? "該当する顧客が見つかりませんでした"
+										: "顧客が登録されていません"}
+								</TableCell>
+							</TableRow>
+						) : (
+							customers.map((customer) => (
+								<TableRow key={customer.customerId}>
+									<TableCell className="font-medium">{customer.name}</TableCell>
+									<TableCell>{customer.email}</TableCell>
+									<TableCell>
+										{new Date(customer.createdAt).toLocaleDateString("ja-JP", {
+											day: "2-digit",
+											month: "2-digit",
+											year: "numeric",
+										})}
+									</TableCell>
+								</TableRow>
+							))
+						)}
+					</TableBody>
+				</Table>
+			</div>
+
+			{/* Pagination */}
+			{totalPages > 1 && (
+				<div className="flex items-center justify-center gap-2">
+					<Button
+						asChild={page > 1}
+						disabled={page <= 1}
+						size="sm"
+						variant="outline"
+					>
+						{page > 1 ? (
+							<Link
+								href={`/customers?${new URLSearchParams({
+									...(keyword ? { keyword } : {}),
+									page: String(page - 1),
+								}).toString()}`}
+							>
+								<ChevronLeft className="size-4 mr-1" />
+								前へ
+							</Link>
+						) : (
+							<>
+								<ChevronLeft className="size-4 mr-1" />
+								前へ
+							</>
+						)}
+					</Button>
+
+					<span className="text-sm text-muted-foreground px-4">
+						{page} / {totalPages}
+					</span>
+
+					<Button
+						asChild={page < totalPages}
+						disabled={page >= totalPages}
+						size="sm"
+						variant="outline"
+					>
+						{page < totalPages ? (
+							<Link
+								href={`/customers?${new URLSearchParams({
+									...(keyword ? { keyword } : {}),
+									page: String(page + 1),
+								}).toString()}`}
+							>
+								次へ
+								<ChevronRight className="size-4 ml-1" />
+							</Link>
+						) : (
+							<>
+								次へ
+								<ChevronRight className="size-4 ml-1" />
+							</>
+						)}
+					</Button>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/web/app/customers/customers-skeleton.tsx
+++ b/apps/web/app/customers/customers-skeleton.tsx
@@ -1,0 +1,52 @@
+import { Skeleton } from "@workspace/ui/components/skeleton";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@workspace/ui/components/table";
+
+export function CustomersSkeleton() {
+	return (
+		<div className="space-y-4">
+			<div className="flex items-center justify-between">
+				<Skeleton className="h-10 w-[300px]" />
+			</div>
+
+			<div className="rounded-md border">
+				<Table>
+					<TableHeader>
+						<TableRow>
+							<TableHead className="w-[300px]">名前</TableHead>
+							<TableHead>メールアドレス</TableHead>
+							<TableHead className="w-[180px]">登録日</TableHead>
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{Array.from({ length: 5 }).map((_, index) => (
+							<TableRow key={index}>
+								<TableCell>
+									<Skeleton className="h-5 w-[200px]" />
+								</TableCell>
+								<TableCell>
+									<Skeleton className="h-5 w-[250px]" />
+								</TableCell>
+								<TableCell>
+									<Skeleton className="h-5 w-[140px]" />
+								</TableCell>
+							</TableRow>
+						))}
+					</TableBody>
+				</Table>
+			</div>
+
+			<div className="flex items-center justify-center gap-2">
+				<Skeleton className="h-10 w-[80px]" />
+				<Skeleton className="h-10 w-[100px]" />
+				<Skeleton className="h-10 w-[80px]" />
+			</div>
+		</div>
+	);
+}

--- a/apps/web/app/customers/page.tsx
+++ b/apps/web/app/customers/page.tsx
@@ -1,0 +1,45 @@
+import type { Metadata } from "next";
+import { Suspense } from "react";
+import { CustomerSearchForm } from "./customer-search-form";
+import { CustomersContainer } from "./customers-container";
+import { CustomersSkeleton } from "./customers-skeleton";
+
+export const metadata: Metadata = {
+	description: "登録されている顧客の一覧を表示します",
+	title: "顧客一覧",
+};
+
+type CustomersPageProps = {
+	searchParams: Promise<{
+		keyword?: string;
+		page?: string;
+	}>;
+};
+
+export default async function CustomersPage({
+	searchParams,
+}: CustomersPageProps) {
+	const params = await searchParams;
+
+	return (
+		<div className="container mx-auto py-8 px-4">
+			<div className="space-y-6">
+				<div>
+					<h1 className="text-3xl font-bold tracking-tight">顧客一覧</h1>
+					<p className="text-muted-foreground mt-2">
+						登録されている顧客を検索・閲覧できます
+					</p>
+				</div>
+
+				<CustomerSearchForm />
+
+				<Suspense
+					fallback={<CustomersSkeleton />}
+					key={`${params.keyword}-${params.page}`}
+				>
+					<CustomersContainer keyword={params.keyword} page={params.page} />
+				</Suspense>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/features/customer/get-customers.ts
+++ b/apps/web/features/customer/get-customers.ts
@@ -1,0 +1,56 @@
+import { db } from "@workspace/db/client";
+import { customersTable, type SelectCustomer } from "@workspace/db/schema";
+import { count, ilike, or } from "drizzle-orm";
+
+export type GetCustomersParams = {
+	keyword?: string;
+	page?: number;
+	pageSize?: number;
+};
+
+export type GetCustomersResult = {
+	customers: SelectCustomer[];
+	total: number;
+	page: number;
+	pageSize: number;
+	totalPages: number;
+};
+
+export async function getCustomers(
+	params: GetCustomersParams = {},
+): Promise<GetCustomersResult> {
+	const { keyword, page = 1, pageSize = 20 } = params;
+
+	// Build where clause
+	const whereConditions = keyword
+		? or(
+				ilike(customersTable.name, `%${keyword}%`),
+				ilike(customersTable.email, `%${keyword}%`),
+			)
+		: undefined;
+
+	// Get total count
+	const [{ value: total }] = await db
+		.select({ value: count() })
+		.from(customersTable)
+		.where(whereConditions);
+
+	// Get paginated customers
+	const customers = await db
+		.select()
+		.from(customersTable)
+		.where(whereConditions)
+		.orderBy(customersTable.createdAt)
+		.limit(pageSize)
+		.offset((page - 1) * pageSize);
+
+	const totalPages = Math.ceil(total / pageSize);
+
+	return {
+		customers,
+		page,
+		pageSize,
+		total,
+		totalPages,
+	};
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,6 +5,7 @@
 		"@repo/supabase": "workspace:",
 		"@workspace/db": "workspace:",
 		"@workspace/ui": "workspace:",
+		"drizzle-orm": "catalog:",
 		"lucide-react": "catalog:",
 		"next": "catalog:",
 		"react": "catalog:",

--- a/cspell.json
+++ b/cspell.json
@@ -13,6 +13,7 @@
 		"FORMAWORK",
 		"harusame",
 		"hookform",
+		"ilike",
 		"knip",
 		"lucide",
 		"supabase",

--- a/packages/ui/src/components/skeleton.tsx
+++ b/packages/ui/src/components/skeleton.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@workspace/ui/lib/utils";
+
+function Skeleton({
+	className,
+	...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+	return (
+		<div
+			className={cn("animate-pulse rounded-md bg-primary/10", className)}
+			{...props}
+		/>
+	);
+}
+
+export { Skeleton };

--- a/packages/ui/src/components/table.tsx
+++ b/packages/ui/src/components/table.tsx
@@ -1,0 +1,115 @@
+import { cn } from "@workspace/ui/lib/utils";
+import type * as React from "react";
+
+function Table({
+	className,
+	...props
+}: React.HTMLAttributes<HTMLTableElement>) {
+	return (
+		<div className="relative w-full overflow-auto">
+			<table
+				className={cn("w-full caption-bottom text-sm", className)}
+				{...props}
+			/>
+		</div>
+	);
+}
+
+function TableHeader({
+	className,
+	...props
+}: React.HTMLAttributes<HTMLTableSectionElement>) {
+	return <thead className={cn("[&_tr]:border-b", className)} {...props} />;
+}
+
+function TableBody({
+	className,
+	...props
+}: React.HTMLAttributes<HTMLTableSectionElement>) {
+	return (
+		<tbody className={cn("[&_tr:last-child]:border-0", className)} {...props} />
+	);
+}
+
+function TableFooter({
+	className,
+	...props
+}: React.HTMLAttributes<HTMLTableSectionElement>) {
+	return (
+		<tfoot
+			className={cn(
+				"border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function TableRow({
+	className,
+	...props
+}: React.HTMLAttributes<HTMLTableRowElement>) {
+	return (
+		<tr
+			className={cn(
+				"border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function TableHead({
+	className,
+	...props
+}: React.ThHTMLAttributes<HTMLTableCellElement>) {
+	return (
+		<th
+			className={cn(
+				"h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function TableCell({
+	className,
+	...props
+}: React.TdHTMLAttributes<HTMLTableCellElement>) {
+	return (
+		<td
+			className={cn(
+				"p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function TableCaption({
+	className,
+	...props
+}: React.HTMLAttributes<HTMLTableCaptionElement>) {
+	return (
+		<caption
+			className={cn("mt-4 text-sm text-muted-foreground", className)}
+			{...props}
+		/>
+	);
+}
+
+export {
+	Table,
+	TableBody,
+	TableCaption,
+	TableCell,
+	TableFooter,
+	TableHead,
+	TableHeader,
+	TableRow,
+};


### PR DESCRIPTION
- /customers に顧客一覧ページを追加
- キーワード検索機能（名前、メールアドレス）
- ページネーション機能（20件/ページ）
- 認証チェック付きのServer Component実装
- Cache Components対応（use cache: remote）
- Table、Skeletonコンポーネントの追加