### PR TITLE
型チェック

### DIFF
--- a/.github/workflows/static-analytics.yml
+++ b/.github/workflows/static-analytics.yml
@@ -6,10 +6,15 @@ on:
     branches:
       - main
 
+concurrency:
+  group: static-analytics-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint と Format のチェック
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: コードをチェックアウト
@@ -27,10 +32,5 @@ jobs:
       - name: 依存関係をインストール
         run: pnpm install --frozen-lockfile
 
-      - name: Lint & Format チェック
-        run: pnpm biome ci .
-
-      - name: デッドコードチェック
-        run: pnpm knip
-      - name: スペルチェック
-        run: pnpm cspell .
+      - name: バリデーションチェック
+        run: pnpm validate:check

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -30,7 +30,8 @@
 		"dev": "next dev",
 		"format": "biome format --write .",
 		"lint": "biome lint .",
-		"start": "next start"
+		"start": "next start",
+		"type:check": "tsc --noEmit"
 	},
 	"version": "0.1.0"
 }

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -1,5 +1,6 @@
 {
 	"$schema": "https://unpkg.com/knip@5/schema.json",
+	"ignoreBinaries": ["type:check"],
 	"ignoreDependencies": [],
 	"workspaces": {
 		"apps/web": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	},
 	"packageManager": "pnpm@10.12.4",
 	"scripts": {
-		"validate:check": "biome check . && knip && cspell .",
+		"validate:check": "biome check . && knip && cspell . && pnpm -r type:check",
 		"validate:fix": "biome check --write . && knip --fix --allow-remove-files"
 	}
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -21,7 +21,8 @@
 		"db:migrate": "drizzle-kit migrate",
 		"db:push": "drizzle-kit push",
 		"db:reset": "pnpm --filter @repo/supabase supabase:reset && pnpm db:push ",
-		"db:studio": "drizzle-kit studio"
+		"db:studio": "drizzle-kit studio",
+		"type:check": "tsc --noEmit"
 	},
 	"type": "module",
 	"version": "0.0.0"

--- a/packages/supabase/package.json
+++ b/packages/supabase/package.json
@@ -20,7 +20,8 @@
 	"scripts": {
 		"seed": "node --env-file-if-exists=.env --experimental-strip-types src/seed.ts",
 		"supabase:reset": "supabase db reset && pnpm seed",
-		"supabase:start": "supabase start"
+		"supabase:start": "supabase start",
+		"type:check": "tsc --noEmit"
 	},
 	"version": "0.0.0"
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -30,7 +30,9 @@
 	},
 	"name": "@workspace/ui",
 	"private": true,
-	"scripts": {},
+	"scripts": {
+		"type:check": "tsc --noEmit"
+	},
 	"type": "module",
 	"version": "0.0.0"
 }


### PR DESCRIPTION
- 各パッケージ(db, supabase, ui, web)にtype:checkスクリプトを追加
- ルートのvalidate:checkでpnpm -r type:checkを実行し、全パッケージの型チェックを実施
- CIワークフローをvalidate:checkに統一し、個別コマンド実行を廃止
- knip設定にignoreBinariesを追加し、type:checkの誤検知を回避
- GitHub Actionsワークフローにconcurrencyとtimeout-minutes設定を追加