### PR TITLE
環境変数設定のリファクタリング

### DIFF
--- a/apps/web/config/logger.ts
+++ b/apps/web/config/logger.ts
@@ -1,20 +1,15 @@
 import * as v from "valibot";
 
-const envSchema = v.object({
-	VERCEL_DEPLOYMENT_ID: v.optional(v.string()),
-	VERCEL_GIT_COMMIT_SHA: v.optional(v.string()),
-});
 
 export function getLoggerConfig() {
-	const parsed = v.parse(envSchema, {
+	return v.parse(v.object({
+		deploymentId: v.optional(v.string()),
+		gitCommitSha: v.optional(v.string()),
+	}), {
 		// biome-ignore lint/complexity/useLiteralKeys: ts(4111)
-		VERCEL_DEPLOYMENT_ID: process.env["VERCEL_DEPLOYMENT_ID"],
+		deploymentId: process.env["VERCEL_DEPLOYMENT_ID"],
 		// biome-ignore lint/complexity/useLiteralKeys: ts(4111)
-		VERCEL_GIT_COMMIT_SHA: process.env["VERCEL_GIT_COMMIT_SHA"],
+		gitCommitSha: process.env["VERCEL_GIT_COMMIT_SHA"],
 	});
 
-	return {
-		deploymentId: parsed.VERCEL_DEPLOYMENT_ID,
-		gitCommitSha: parsed.VERCEL_GIT_COMMIT_SHA,
-	};
 }

--- a/apps/web/config/logger.ts
+++ b/apps/web/config/logger.ts
@@ -1,15 +1,16 @@
 import * as v from "valibot";
 
-
 export function getLoggerConfig() {
-	return v.parse(v.object({
-		deploymentId: v.optional(v.string()),
-		gitCommitSha: v.optional(v.string()),
-	}), {
-		// biome-ignore lint/complexity/useLiteralKeys: ts(4111)
-		deploymentId: process.env["VERCEL_DEPLOYMENT_ID"],
-		// biome-ignore lint/complexity/useLiteralKeys: ts(4111)
-		gitCommitSha: process.env["VERCEL_GIT_COMMIT_SHA"],
-	});
-
+	return v.parse(
+		v.object({
+			deploymentId: v.optional(v.string()),
+			gitCommitSha: v.optional(v.string()),
+		}),
+		{
+			// biome-ignore lint/complexity/useLiteralKeys: ts(4111)
+			deploymentId: process.env["VERCEL_DEPLOYMENT_ID"],
+			// biome-ignore lint/complexity/useLiteralKeys: ts(4111)
+			gitCommitSha: process.env["VERCEL_GIT_COMMIT_SHA"],
+		},
+	);
 }

--- a/packages/logger/src/config.ts
+++ b/packages/logger/src/config.ts
@@ -25,13 +25,13 @@ export function getLoggerConfig(): LoggerConfig {
 		}),
 		{
 			// biome-ignore lint/complexity/useLiteralKeys: ts(4111)
-			APP_NAME: process.env["APP_NAME"],
+			application: process.env["APP_NAME"],
 			// biome-ignore lint/complexity/useLiteralKeys: ts(4111)
-			HOST_ENVIRONMENT: process.env["HOST_ENVIRONMENT"],
+			environment: process.env["HOST_ENVIRONMENT"],
 			// biome-ignore lint/complexity/useLiteralKeys: ts(4111)
-			LOG_LEVEL: process.env["LOG_LEVEL"],
+			level: process.env["LOG_LEVEL"],
 			// biome-ignore lint/complexity/useLiteralKeys: ts(4111)
-			SERVICE_NAME: process.env["SERVICE_NAME"],
+			service: process.env["SERVICE_NAME"],
 		},
 	);
 }


### PR DESCRIPTION
## Summary
- ロガー設定とWeb設定で環境変数のパース処理をシンプル化
- valibotのスキーマで直接目的のキー名を使用することで中間オブジェクトの変換処理を削減
- コードの可読性と保守性を向上

## 変更内容

### `packages/logger/src/config.ts`
- `v.parse()` 時に環境変数名ではなく、最終的に使用するキー名（`application`, `environment`, `level`, `service`）を直接使用
- 変換処理が不要になり、コードが簡潔に

### `apps/web/config/logger.ts`
- 同様に `v.parse()` 時に最終的なキー名（`deploymentId`, `gitCommitSha`）を使用
- 中間オブジェクトと変換処理を削除

## Test plan
- [ ] バリデーションチェックが通ること（`pnpm validate:check`）
- [ ] 型エラーがないこと
- [ ] 既存のログ出力が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)