### PR TITLE
Build customer list page with search and pagination

### DIFF
--- a/apps/web/app/customers/customers-container.tsx
+++ b/apps/web/app/customers/customers-container.tsx
@@ -1,0 +1,30 @@
+import { searchCustomersAction } from "./search-customers-action";
+import { CustomersPresenter } from "./customers-presenter";
+
+type CustomersContainerProps = {
+	searchParams: Promise<{ keyword?: string; page?: string }>;
+};
+
+export async function CustomersContainer({
+	searchParams,
+}: CustomersContainerProps) {
+	const params = await searchParams;
+	const keyword = params.keyword || "";
+	const page = params.page ? Number.parseInt(params.page, 10) : 1;
+
+	const result = await searchCustomersAction({
+		keyword,
+		page,
+		pageSize: 20,
+	});
+
+	if (!result.success) {
+		return (
+			<div className="text-center text-red-600">
+				顧客一覧の取得に失敗しました
+			</div>
+		);
+	}
+
+	return <CustomersPresenter data={result.data} keyword={keyword} />;
+}

--- a/apps/web/app/customers/customers-pagination.tsx
+++ b/apps/web/app/customers/customers-pagination.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import {
+	Pagination,
+	PaginationContent,
+	PaginationEllipsis,
+	PaginationItem,
+	PaginationLink,
+	PaginationNext,
+	PaginationPrevious,
+} from "@workspace/ui/components/pagination";
+import { useSearchParams } from "next/navigation";
+
+type CustomersPaginationProps = {
+	currentPage: number;
+	totalPages: number;
+	totalCount: number;
+};
+
+export function CustomersPagination({
+	currentPage,
+	totalPages,
+	totalCount,
+}: CustomersPaginationProps) {
+	const searchParams = useSearchParams();
+
+	function createPageUrl(page: number) {
+		const params = new URLSearchParams(searchParams);
+		params.set("page", page.toString());
+		return `/customers?${params.toString()}`;
+	}
+
+	if (totalPages <= 1) {
+		return (
+			<div className="text-sm text-muted-foreground">
+				全{totalCount}件
+			</div>
+		);
+	}
+
+	// ページ番号の生成ロジック
+	const pages: (number | "ellipsis")[] = [];
+	const showEllipsisStart = currentPage > 3;
+	const showEllipsisEnd = currentPage < totalPages - 2;
+
+	if (showEllipsisStart) {
+		pages.push(1);
+		pages.push("ellipsis");
+	} else {
+		for (let i = 1; i < currentPage; i++) {
+			pages.push(i);
+		}
+	}
+
+	pages.push(currentPage);
+
+	if (showEllipsisEnd) {
+		pages.push("ellipsis");
+		pages.push(totalPages);
+	} else {
+		for (let i = currentPage + 1; i <= totalPages; i++) {
+			pages.push(i);
+		}
+	}
+
+	return (
+		<div className="flex items-center justify-between">
+			<div className="text-sm text-muted-foreground">
+				全{totalCount}件 ({currentPage} / {totalPages}ページ)
+			</div>
+			<Pagination>
+				<PaginationContent>
+					{currentPage > 1 && (
+						<PaginationItem>
+							<PaginationPrevious href={createPageUrl(currentPage - 1)} />
+						</PaginationItem>
+					)}
+					{pages.map((page, index) =>
+						page === "ellipsis" ? (
+							<PaginationItem key={`ellipsis-${index}`}>
+								<PaginationEllipsis />
+							</PaginationItem>
+						) : (
+							<PaginationItem key={page}>
+								<PaginationLink
+									href={createPageUrl(page)}
+									isActive={page === currentPage}
+								>
+									{page}
+								</PaginationLink>
+							</PaginationItem>
+						),
+					)}
+					{currentPage < totalPages && (
+						<PaginationItem>
+							<PaginationNext href={createPageUrl(currentPage + 1)} />
+						</PaginationItem>
+					)}
+				</PaginationContent>
+			</Pagination>
+		</div>
+	);
+}

--- a/apps/web/app/customers/customers-presenter.tsx
+++ b/apps/web/app/customers/customers-presenter.tsx
@@ -1,0 +1,26 @@
+import type { SearchCustomersResult } from "../../features/customer/search-customers";
+import { SearchForm } from "./search-form";
+import { CustomersTable } from "./customers-table";
+import { CustomersPagination } from "./customers-pagination";
+
+type CustomersPresenterProps = {
+	data: SearchCustomersResult;
+	keyword: string;
+};
+
+export function CustomersPresenter({
+	data,
+	keyword,
+}: CustomersPresenterProps) {
+	return (
+		<div className="space-y-6">
+			<SearchForm defaultKeyword={keyword} />
+			<CustomersTable customers={data.customers} />
+			<CustomersPagination
+				currentPage={data.page}
+				totalPages={data.totalPages}
+				totalCount={data.totalCount}
+			/>
+		</div>
+	);
+}

--- a/apps/web/app/customers/customers-table.tsx
+++ b/apps/web/app/customers/customers-table.tsx
@@ -1,0 +1,48 @@
+import type { SelectCustomer } from "@workspace/db/schema/customer";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@workspace/ui/components/table";
+
+type CustomersTableProps = {
+	customers: SelectCustomer[];
+};
+
+export function CustomersTable({ customers }: CustomersTableProps) {
+	if (customers.length === 0) {
+		return (
+			<div className="py-8 text-center text-muted-foreground">
+				該当する顧客が見つかりませんでした
+			</div>
+		);
+	}
+
+	return (
+		<Table>
+			<TableHeader>
+				<TableRow>
+					<TableHead>名前</TableHead>
+					<TableHead>メールアドレス</TableHead>
+					<TableHead>電話番号</TableHead>
+					<TableHead>登録日</TableHead>
+				</TableRow>
+			</TableHeader>
+			<TableBody>
+				{customers.map((customer) => (
+					<TableRow key={customer.customerId}>
+						<TableCell>{customer.name}</TableCell>
+						<TableCell>{customer.email}</TableCell>
+						<TableCell>{customer.phoneNumber || "-"}</TableCell>
+						<TableCell>
+							{new Date(customer.createdAt).toLocaleDateString("ja-JP")}
+						</TableCell>
+					</TableRow>
+				))}
+			</TableBody>
+		</Table>
+	);
+}

--- a/apps/web/app/customers/page.tsx
+++ b/apps/web/app/customers/page.tsx
@@ -1,0 +1,17 @@
+import { Card } from "@workspace/ui/components/card";
+import { CustomersContainer } from "./customers-container";
+
+export default function CustomersPage({
+	searchParams,
+}: {
+	searchParams: Promise<{ keyword?: string; page?: string }>;
+}) {
+	return (
+		<div className="container mx-auto py-8">
+			<h1 className="mb-6 text-3xl font-bold">顧客一覧</h1>
+			<Card className="p-6">
+				<CustomersContainer searchParams={searchParams} />
+			</Card>
+		</div>
+	);
+}

--- a/apps/web/app/customers/search-customers-action.server.test.ts
+++ b/apps/web/app/customers/search-customers-action.server.test.ts
@@ -1,0 +1,79 @@
+import { describe, test, expect, beforeEach } from "vitest";
+import { db } from "@workspace/db/client";
+import { customersTable } from "@workspace/db/schema/customer";
+import { searchCustomersAction } from "./search-customers-action";
+
+describe("searchCustomersAction", () => {
+	beforeEach(async () => {
+		// テストデータをクリア
+		await db.delete(customersTable);
+
+		// テストデータを挿入
+		await db.insert(customersTable).values([
+			{
+				name: "テスト顧客1",
+				email: "test1@example.com",
+				phoneNumber: "090-1111-1111",
+			},
+			{
+				name: "テスト顧客2",
+				email: "test2@example.com",
+				phoneNumber: "090-2222-2222",
+			},
+		]);
+	});
+
+	test("正常なパラメータで顧客一覧を取得できる", async () => {
+		const result = await searchCustomersAction({
+			keyword: "",
+			page: 1,
+			pageSize: 20,
+		});
+
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.customers).toHaveLength(2);
+			expect(result.data.totalCount).toBe(2);
+		}
+	});
+
+	test("キーワード検索が動作する", async () => {
+		const result = await searchCustomersAction({
+			keyword: "テスト顧客1",
+			page: 1,
+			pageSize: 20,
+		});
+
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.customers).toHaveLength(1);
+			expect(result.data.customers[0]?.name).toBe("テスト顧客1");
+		}
+	});
+
+	test("不正なページ番号でバリデーションエラーになる", async () => {
+		const result = await searchCustomersAction({
+			keyword: "",
+			page: 0,
+			pageSize: 20,
+		});
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error).toBe("VALIDATION_ERROR");
+		}
+	});
+
+	test("不正なページサイズでバリデーションエラーになる", async () => {
+		const result = await searchCustomersAction({
+			keyword: "",
+			page: 1,
+			pageSize: 101,
+		});
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error).toBe("VALIDATION_ERROR");
+		}
+	});
+});

--- a/apps/web/app/customers/search-customers-action.ts
+++ b/apps/web/app/customers/search-customers-action.ts
@@ -1,0 +1,48 @@
+"use server";
+
+import { fail, type Result } from "@harusame0616/result";
+import { getLogger } from "@repo/logger/nextjs/server";
+import {
+	searchCustomers,
+	type SearchCustomersError,
+	type SearchCustomersResult,
+} from "../../features/customer/search-customers";
+import {
+	searchCustomersSchema,
+	type SearchCustomersSchema,
+} from "../../features/customer/schema";
+import * as v from "valibot";
+
+export type SearchCustomersActionErrorMessage =
+	| "VALIDATION_ERROR"
+	| "SEARCH_ERROR";
+
+export async function searchCustomersAction(
+	params: SearchCustomersSchema,
+): Promise<Result<SearchCustomersResult, SearchCustomersActionErrorMessage>> {
+	const logger = getLogger();
+
+	// バリデーション
+	const paramsParseResult = v.safeParse(searchCustomersSchema, params);
+	if (!paramsParseResult.success) {
+		logger.warn(
+			"Validation error in searchCustomersAction",
+			{ error: paramsParseResult.issues },
+		);
+		return fail("VALIDATION_ERROR");
+	}
+
+	// 顧客検索実行
+	logger.info("Searching customers", { params: paramsParseResult.output });
+	const result = await searchCustomers(paramsParseResult.output);
+
+	if (!result.success) {
+		logger.error("Failed to search customers", { error: result.error });
+		return fail("SEARCH_ERROR");
+	}
+
+	logger.info("Successfully searched customers", {
+		totalCount: result.data.totalCount,
+	});
+	return result;
+}

--- a/apps/web/app/customers/search-form.browser.test.tsx
+++ b/apps/web/app/customers/search-form.browser.test.tsx
@@ -1,0 +1,76 @@
+import { test, expect, vi } from "vitest";
+import { page } from "vitest/browser";
+import { render } from "vitest-browser-react";
+import { SearchForm } from "./search-form";
+
+// useRouter と useSearchParams をモック
+vi.mock("next/navigation", () => ({
+	useRouter: vi.fn(() => ({
+		push: vi.fn(),
+	})),
+	useSearchParams: vi.fn(() => new URLSearchParams()),
+}));
+
+test("初期状態でデフォルトのキーワードが入力欄に表示される", async () => {
+	render(<SearchForm defaultKeyword="テスト" />);
+
+	const input = page.getByPlaceholder(
+		"名前、メールアドレス、電話番号で検索",
+	);
+	await expect.element(input).toHaveValue("テスト");
+});
+
+test("空のキーワードで初期化される", async () => {
+	render(<SearchForm defaultKeyword="" />);
+
+	const input = page.getByPlaceholder(
+		"名前、メールアドレス、電話番号で検索",
+	);
+	await expect.element(input).toHaveValue("");
+});
+
+test("検索ボタンが表示される", async () => {
+	render(<SearchForm defaultKeyword="" />);
+
+	const button = page.getByRole("button", { name: /検索/ });
+	await expect.element(button).toBeInTheDocument();
+});
+
+test("入力欄にテキストを入力できる", async () => {
+	render(<SearchForm defaultKeyword="" />);
+
+	const input = page.getByPlaceholder(
+		"名前、メールアドレス、電話番号で検索",
+	);
+	await input.fill("山田太郎");
+
+	await expect.element(input).toHaveValue("山田太郎");
+});
+
+test("フォーム送信時にrouterのpushが呼ばれる", async () => {
+	const pushMock = vi.fn();
+	const { useRouter } = await import("next/navigation");
+	vi.mocked(useRouter).mockReturnValue({
+		push: pushMock,
+		replace: vi.fn(),
+		refresh: vi.fn(),
+		back: vi.fn(),
+		forward: vi.fn(),
+		prefetch: vi.fn(),
+	});
+
+	render(<SearchForm defaultKeyword="" />);
+
+	const input = page.getByPlaceholder(
+		"名前、メールアドレス、電話番号で検索",
+	);
+	await input.fill("テスト検索");
+
+	const button = page.getByRole("button", { name: /検索/ });
+	await button.click();
+
+	// 非同期処理が完了するまで待機
+	await vi.waitFor(() => {
+		expect(pushMock).toHaveBeenCalled();
+	});
+});

--- a/apps/web/app/customers/search-form.tsx
+++ b/apps/web/app/customers/search-form.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { Button } from "@workspace/ui/components/button";
+import { Input } from "@workspace/ui/components/input";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState, useTransition } from "react";
+import { useIsHydrated } from "../../libs/use-is-hydrated";
+import { Search } from "lucide-react";
+
+type SearchFormProps = {
+	defaultKeyword: string;
+};
+
+export function SearchForm({ defaultKeyword }: SearchFormProps) {
+	const router = useRouter();
+	const searchParams = useSearchParams();
+	const [keyword, setKeyword] = useState(defaultKeyword);
+	const [isPending, startTransition] = useTransition();
+	const isHydrated = useIsHydrated();
+
+	function handleSubmit(e: React.FormEvent) {
+		e.preventDefault();
+		startTransition(() => {
+			const params = new URLSearchParams(searchParams);
+			if (keyword) {
+				params.set("keyword", keyword);
+			} else {
+				params.delete("keyword");
+			}
+			params.delete("page"); // Reset to page 1 on new search
+			router.push(`/customers?${params.toString()}`);
+		});
+	}
+
+	return (
+		<form onSubmit={handleSubmit} className="flex gap-2">
+			<Input
+				type="text"
+				placeholder="名前、メールアドレス、電話番号で検索"
+				value={keyword}
+				onChange={(e) => setKeyword(e.target.value)}
+				disabled={!isHydrated || isPending}
+				className="flex-1"
+			/>
+			<Button type="submit" disabled={!isHydrated || isPending}>
+				<Search className="mr-2 h-4 w-4" />
+				検索
+			</Button>
+		</form>
+	);
+}

--- a/apps/web/e2e/customers.e2e.test.ts
+++ b/apps/web/e2e/customers.e2e.test.ts
@@ -1,0 +1,160 @@
+import { test as base, expect } from "@playwright/test";
+import { db } from "@workspace/db/client";
+import { customersTable } from "@workspace/db/schema/customer";
+import { inArray } from "drizzle-orm";
+
+type CustomersFixture = {
+	testCustomers: Array<{
+		name: string;
+		email: string;
+		phoneNumber: string | null;
+	}>;
+};
+
+const test = base.extend<CustomersFixture>({
+	testCustomers: async (
+		// biome-ignore lint/correctness/noEmptyPattern: Playwrightのfixtureパターンで使用する標準的な記法
+		{},
+		use,
+	) => {
+		// テストデータを作成
+		const testData = [
+			{
+				name: "山田太郎",
+				email: "yamada@example.com",
+				phoneNumber: "090-1234-5678",
+			},
+			{
+				name: "佐藤花子",
+				email: "sato@example.com",
+				phoneNumber: "080-9876-5432",
+			},
+			{
+				name: "鈴木一郎",
+				email: "suzuki@example.com",
+				phoneNumber: null,
+			},
+		];
+
+		// データを挿入
+		await db.insert(customersTable).values(testData);
+
+		await use(testData);
+
+		// クリーンアップ（テスト用のデータを削除）
+		await db
+			.delete(customersTable)
+			.where(
+				inArray(
+					customersTable.email,
+					testData.map((d) => d.email),
+				),
+			);
+	},
+});
+
+test("顧客一覧ページが正しく表示される", async ({ page, testCustomers }) => {
+	await test.step("ページに遷移", async () => {
+		await page.goto("http://localhost:3000/customers");
+		await expect(page).toHaveURL(/\/customers/);
+	});
+
+	await test.step("タイトルが表示される", async () => {
+		await expect(page.getByRole("heading", { name: "顧客一覧" })).toBeVisible();
+	});
+
+	await test.step("検索フォームが表示される", async () => {
+		await expect(
+			page.getByPlaceholder("名前、メールアドレス、電話番号で検索"),
+		).toBeVisible();
+		await expect(page.getByRole("button", { name: /検索/ })).toBeVisible();
+	});
+
+	await test.step("顧客データが表示される", async () => {
+		// テーブルが表示される
+		await expect(page.getByRole("table")).toBeVisible();
+
+		// テストデータが表示されることを確認
+		await expect(page.getByText("山田太郎")).toBeVisible();
+		await expect(page.getByText("yamada@example.com")).toBeVisible();
+		await expect(page.getByText("090-1234-5678")).toBeVisible();
+	});
+});
+
+test("名前で検索できる", async ({ page, testCustomers }) => {
+	await test.step("ページに遷移", async () => {
+		await page.goto("http://localhost:3000/customers");
+	});
+
+	await test.step("名前で検索", async () => {
+		await page
+			.getByPlaceholder("名前、メールアドレス、電話番号で検索")
+			.fill("山田");
+		await page.getByRole("button", { name: /検索/ }).click();
+		await page.waitForURL(/keyword=山田/);
+	});
+
+	await test.step("検索結果が表示される", async () => {
+		await expect(page.getByText("山田太郎")).toBeVisible();
+		await expect(page.getByText("佐藤花子")).not.toBeVisible();
+	});
+});
+
+test("メールアドレスで検索できる", async ({ page, testCustomers }) => {
+	await test.step("ページに遷移", async () => {
+		await page.goto("http://localhost:3000/customers");
+	});
+
+	await test.step("メールアドレスで検索", async () => {
+		await page
+			.getByPlaceholder("名前、メールアドレス、電話番号で検索")
+			.fill("sato@");
+		await page.getByRole("button", { name: /検索/ }).click();
+		await page.waitForURL(/keyword=sato/);
+	});
+
+	await test.step("検索結果が表示される", async () => {
+		await expect(page.getByText("佐藤花子")).toBeVisible();
+		await expect(page.getByText("山田太郎")).not.toBeVisible();
+	});
+});
+
+test("電話番号で検索できる", async ({ page, testCustomers }) => {
+	await test.step("ページに遷移", async () => {
+		await page.goto("http://localhost:3000/customers");
+	});
+
+	await test.step("電話番号で検索", async () => {
+		await page
+			.getByPlaceholder("名前、メールアドレス、電話番号で検索")
+			.fill("090-1234");
+		await page.getByRole("button", { name: /検索/ }).click();
+		await page.waitForURL(/keyword=090-1234/);
+	});
+
+	await test.step("検索結果が表示される", async () => {
+		await expect(page.getByText("山田太郎")).toBeVisible();
+		await expect(page.getByText("090-1234-5678")).toBeVisible();
+		await expect(page.getByText("佐藤花子")).not.toBeVisible();
+	});
+});
+
+test("該当なしの場合にメッセージが表示される", async ({ page }) => {
+	await test.step("ページに遷移", async () => {
+		await page.goto("http://localhost:3000/customers");
+	});
+
+	await test.step("存在しないキーワードで検索", async () => {
+		await page
+			.getByPlaceholder("名前、メールアドレス、電話番号で検索")
+			.fill("存在しない顧客");
+		await page.getByRole("button", { name: /検索/ }).click();
+		await page.waitForURL(/keyword/);
+	});
+
+	await test.step("該当なしメッセージが表示される", async () => {
+		await expect(
+			page.getByText("該当する顧客が見つかりませんでした"),
+		).toBeVisible();
+	});
+});

--- a/apps/web/features/customer/schema.server.test.ts
+++ b/apps/web/features/customer/schema.server.test.ts
@@ -1,0 +1,54 @@
+import { describe, test, expect } from "vitest";
+import * as v from "valibot";
+import { searchCustomersSchema } from "./schema";
+
+describe("searchCustomersSchema", () => {
+	test("デフォルト値でバリデーションに成功する", () => {
+		const result = v.safeParse(searchCustomersSchema, {});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.output).toEqual({
+				keyword: undefined,
+				page: 1,
+				pageSize: 20,
+			});
+		}
+	});
+
+	test("キーワードありでバリデーションに成功する", () => {
+		const result = v.safeParse(searchCustomersSchema, {
+			keyword: "test",
+			page: 2,
+			pageSize: 10,
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.output).toEqual({
+				keyword: "test",
+				page: 2,
+				pageSize: 10,
+			});
+		}
+	});
+
+	test("ページ番号が0以下の場合バリデーションに失敗する", () => {
+		const result = v.safeParse(searchCustomersSchema, {
+			page: 0,
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test("ページサイズが0以下の場合バリデーションに失敗する", () => {
+		const result = v.safeParse(searchCustomersSchema, {
+			pageSize: 0,
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test("ページサイズが100を超える場合バリデーションに失敗する", () => {
+		const result = v.safeParse(searchCustomersSchema, {
+			pageSize: 101,
+		});
+		expect(result.success).toBe(false);
+	});
+});

--- a/apps/web/features/customer/schema.ts
+++ b/apps/web/features/customer/schema.ts
@@ -1,0 +1,11 @@
+import * as v from "valibot";
+
+export const searchCustomersSchema = v.object({
+	keyword: v.optional(v.string()),
+	page: v.optional(v.pipe(v.number(), v.minValue(1)), 1),
+	pageSize: v.optional(v.pipe(v.number(), v.minValue(1), v.maxValue(100)), 20),
+});
+
+export type SearchCustomersSchema = v.InferOutput<
+	typeof searchCustomersSchema
+>;

--- a/apps/web/features/customer/search-customers.server.test.ts
+++ b/apps/web/features/customer/search-customers.server.test.ts
@@ -1,0 +1,108 @@
+import { describe, test, expect, beforeEach } from "vitest";
+import { db } from "@workspace/db/client";
+import { customersTable } from "@workspace/db/schema/customer";
+import { searchCustomers } from "./search-customers";
+
+describe("searchCustomers", () => {
+	beforeEach(async () => {
+		// テストデータをクリア
+		await db.delete(customersTable);
+
+		// テストデータを挿入
+		await db.insert(customersTable).values([
+			{
+				name: "山田太郎",
+				email: "yamada@example.com",
+				phoneNumber: "090-1234-5678",
+			},
+			{
+				name: "佐藤花子",
+				email: "sato@example.com",
+				phoneNumber: "080-9876-5432",
+			},
+			{
+				name: "鈴木一郎",
+				email: "suzuki@example.com",
+				phoneNumber: null,
+			},
+		]);
+	});
+
+	test("全顧客を取得できる", async () => {
+		const result = await searchCustomers({ page: 1, pageSize: 20 });
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.customers).toHaveLength(3);
+			expect(result.data.totalCount).toBe(3);
+			expect(result.data.page).toBe(1);
+			expect(result.data.pageSize).toBe(20);
+			expect(result.data.totalPages).toBe(1);
+		}
+	});
+
+	test("名前で検索できる", async () => {
+		const result = await searchCustomers({ keyword: "山田", page: 1, pageSize: 20 });
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.customers).toHaveLength(1);
+			expect(result.data.customers[0]?.name).toBe("山田太郎");
+			expect(result.data.totalCount).toBe(1);
+		}
+	});
+
+	test("メールアドレスで検索できる", async () => {
+		const result = await searchCustomers({ keyword: "sato@", page: 1, pageSize: 20 });
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.customers).toHaveLength(1);
+			expect(result.data.customers[0]?.email).toBe("sato@example.com");
+		}
+	});
+
+	test("電話番号で検索できる", async () => {
+		const result = await searchCustomers({ keyword: "090-1234", page: 1, pageSize: 20 });
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.customers).toHaveLength(1);
+			expect(result.data.customers[0]?.phoneNumber).toBe("090-1234-5678");
+		}
+	});
+
+	test("大文字小文字を区別せず検索できる", async () => {
+		const result = await searchCustomers({ keyword: "YAMADA", page: 1, pageSize: 20 });
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.customers).toHaveLength(1);
+			expect(result.data.customers[0]?.email).toBe("yamada@example.com");
+		}
+	});
+
+	test("該当なしの場合は空配列を返す", async () => {
+		const result = await searchCustomers({ keyword: "存在しない", page: 1, pageSize: 20 });
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.customers).toHaveLength(0);
+			expect(result.data.totalCount).toBe(0);
+		}
+	});
+
+	test("ページネーションが正しく動作する", async () => {
+		// 追加のテストデータを挿入
+		for (let i = 4; i <= 25; i++) {
+			await db.insert(customersTable).values({
+				name: `テストユーザー${i}`,
+				email: `test${i}@example.com`,
+				phoneNumber: null,
+			});
+		}
+
+		const result = await searchCustomers({ page: 2, pageSize: 10 });
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.customers).toHaveLength(10);
+			expect(result.data.totalCount).toBe(25);
+			expect(result.data.page).toBe(2);
+			expect(result.data.totalPages).toBe(3);
+		}
+	});
+});

--- a/apps/web/features/customer/search-customers.ts
+++ b/apps/web/features/customer/search-customers.ts
@@ -1,0 +1,64 @@
+import { fail, succeed, type Result } from "@harusame0616/result";
+import { db } from "@workspace/db/client";
+import { customersTable, type SelectCustomer } from "@workspace/db/schema/customer";
+import { and, count, ilike, or, sql } from "drizzle-orm";
+import type { SearchCustomersSchema } from "./schema";
+
+export type SearchCustomersResult = {
+	customers: SelectCustomer[];
+	totalCount: number;
+	page: number;
+	pageSize: number;
+	totalPages: number;
+};
+
+export type SearchCustomersError = {
+	message: string;
+};
+
+export async function searchCustomers(
+	params: SearchCustomersSchema,
+): Promise<Result<SearchCustomersResult, SearchCustomersError>> {
+	try {
+		const { keyword, page = 1, pageSize = 20 } = params;
+
+		// 検索条件の構築
+		const searchConditions = keyword
+			? or(
+					ilike(customersTable.name, `%${keyword}%`),
+					ilike(customersTable.email, `%${keyword}%`),
+					ilike(customersTable.phoneNumber, `%${keyword}%`),
+				)
+			: undefined;
+
+		// 総件数を取得
+		const [countResult] = await db
+			.select({ count: count() })
+			.from(customersTable)
+			.where(searchConditions);
+
+		const totalCount = countResult?.count ?? 0;
+		const totalPages = Math.ceil(totalCount / pageSize);
+
+		// ページネーション付きで顧客一覧を取得
+		const customers = await db
+			.select()
+			.from(customersTable)
+			.where(searchConditions)
+			.orderBy(customersTable.createdAt)
+			.limit(pageSize)
+			.offset((page - 1) * pageSize);
+
+		return succeed({
+			customers,
+			totalCount,
+			page,
+			pageSize,
+			totalPages,
+		});
+	} catch (error) {
+		return fail({
+			message: "顧客一覧の取得に失敗しました",
+		});
+	}
+}

--- a/packages/db/src/schema/customer.ts
+++ b/packages/db/src/schema/customer.ts
@@ -5,6 +5,7 @@ export const customersTable = pgTable("customers", {
 	customerId: uuid("customer_id").primaryKey().defaultRandom(),
 	email: text("email").notNull().unique(),
 	name: text("name").notNull(),
+	phoneNumber: text("phone_number"),
 	updatedAt: timestamp("updated_at")
 		.defaultNow()
 		.notNull()

--- a/packages/ui/src/components/pagination.tsx
+++ b/packages/ui/src/components/pagination.tsx
@@ -1,0 +1,118 @@
+import * as React from "react";
+import { ChevronLeft, ChevronRight, MoreHorizontal } from "lucide-react";
+import type { VariantProps } from "class-variance-authority";
+
+import { cn } from "../lib/utils";
+import { buttonVariants } from "./button";
+
+const Pagination = ({ className, ...props }: React.ComponentProps<"nav">) => (
+	<nav
+		role="navigation"
+		aria-label="pagination"
+		className={cn("mx-auto flex w-full justify-center", className)}
+		{...props}
+	/>
+);
+Pagination.displayName = "Pagination";
+
+const PaginationContent = React.forwardRef<
+	HTMLUListElement,
+	React.ComponentProps<"ul">
+>(({ className, ...props }, ref) => (
+	<ul
+		ref={ref}
+		className={cn("flex flex-row items-center gap-1", className)}
+		{...props}
+	/>
+));
+PaginationContent.displayName = "PaginationContent";
+
+const PaginationItem = React.forwardRef<
+	HTMLLIElement,
+	React.ComponentProps<"li">
+>(({ className, ...props }, ref) => (
+	<li ref={ref} className={cn("", className)} {...props} />
+));
+PaginationItem.displayName = "PaginationItem";
+
+type PaginationLinkProps = {
+	isActive?: boolean;
+	size?: VariantProps<typeof buttonVariants>["size"];
+} & React.ComponentProps<"a">;
+
+const PaginationLink = ({
+	className,
+	isActive,
+	size = "icon",
+	...props
+}: PaginationLinkProps) => (
+	<a
+		aria-current={isActive ? "page" : undefined}
+		className={cn(
+			buttonVariants({
+				variant: isActive ? "outline" : "ghost",
+				size,
+			}),
+			className,
+		)}
+		{...props}
+	/>
+);
+PaginationLink.displayName = "PaginationLink";
+
+const PaginationPrevious = ({
+	className,
+	...props
+}: React.ComponentProps<typeof PaginationLink>) => (
+	<PaginationLink
+		aria-label="Go to previous page"
+		size="default"
+		className={cn("gap-1 pl-2.5", className)}
+		{...props}
+	>
+		<ChevronLeft className="h-4 w-4" />
+		<span>Previous</span>
+	</PaginationLink>
+);
+PaginationPrevious.displayName = "PaginationPrevious";
+
+const PaginationNext = ({
+	className,
+	...props
+}: React.ComponentProps<typeof PaginationLink>) => (
+	<PaginationLink
+		aria-label="Go to next page"
+		size="default"
+		className={cn("gap-1 pr-2.5", className)}
+		{...props}
+	>
+		<span>Next</span>
+		<ChevronRight className="h-4 w-4" />
+	</PaginationLink>
+);
+PaginationNext.displayName = "PaginationNext";
+
+const PaginationEllipsis = ({
+	className,
+	...props
+}: React.ComponentProps<"span">) => (
+	<span
+		aria-hidden
+		className={cn("flex h-9 w-9 items-center justify-center", className)}
+		{...props}
+	>
+		<MoreHorizontal className="h-4 w-4" />
+		<span className="sr-only">More pages</span>
+	</span>
+);
+PaginationEllipsis.displayName = "PaginationEllipsis";
+
+export {
+	Pagination,
+	PaginationContent,
+	PaginationEllipsis,
+	PaginationItem,
+	PaginationLink,
+	PaginationNext,
+	PaginationPrevious,
+};

--- a/packages/ui/src/components/table.tsx
+++ b/packages/ui/src/components/table.tsx
@@ -1,0 +1,120 @@
+import * as React from "react";
+
+import { cn } from "../lib/utils";
+
+const Table = React.forwardRef<
+	HTMLTableElement,
+	React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+	<div className="relative w-full overflow-auto">
+		<table
+			ref={ref}
+			className={cn("w-full caption-bottom text-sm", className)}
+			{...props}
+		/>
+	</div>
+));
+Table.displayName = "Table";
+
+const TableHeader = React.forwardRef<
+	HTMLTableSectionElement,
+	React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+	<thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+));
+TableHeader.displayName = "TableHeader";
+
+const TableBody = React.forwardRef<
+	HTMLTableSectionElement,
+	React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+	<tbody
+		ref={ref}
+		className={cn("[&_tr:last-child]:border-0", className)}
+		{...props}
+	/>
+));
+TableBody.displayName = "TableBody";
+
+const TableFooter = React.forwardRef<
+	HTMLTableSectionElement,
+	React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+	<tfoot
+		ref={ref}
+		className={cn(
+			"border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+			className,
+		)}
+		{...props}
+	/>
+));
+TableFooter.displayName = "TableFooter";
+
+const TableRow = React.forwardRef<
+	HTMLTableRowElement,
+	React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+	<tr
+		ref={ref}
+		className={cn(
+			"border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+			className,
+		)}
+		{...props}
+	/>
+));
+TableRow.displayName = "TableRow";
+
+const TableHead = React.forwardRef<
+	HTMLTableCellElement,
+	React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+	<th
+		ref={ref}
+		className={cn(
+			"h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+			className,
+		)}
+		{...props}
+	/>
+));
+TableHead.displayName = "TableHead";
+
+const TableCell = React.forwardRef<
+	HTMLTableCellElement,
+	React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+	<td
+		ref={ref}
+		className={cn(
+			"p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+			className,
+		)}
+		{...props}
+	/>
+));
+TableCell.displayName = "TableCell";
+
+const TableCaption = React.forwardRef<
+	HTMLTableCaptionElement,
+	React.HTMLAttributes<HTMLTableCaptionElement>
+>(({ className, ...props }, ref) => (
+	<caption
+		ref={ref}
+		className={cn("mt-4 text-sm text-muted-foreground", className)}
+		{...props}
+	/>
+));
+TableCaption.displayName = "TableCaption";
+
+export {
+	Table,
+	TableHeader,
+	TableBody,
+	TableFooter,
+	TableHead,
+	TableRow,
+	TableCell,
+	TableCaption,
+};


### PR DESCRIPTION
- 顧客スキーマに電話番号フィールドを追加
- 名前、メールアドレス、電話番号での検索機能を実装
- ページネーション機能を実装
- shadcn UIのテーブルとページネーションコンポーネントを追加
- バリデーションスキーマ、ビジネスロジック、Server Actionを実装
- スモールテスト、統合テスト、コンポーネントテスト、E2Eテストを実装