### PR TITLE
顧客詳細タブを「レポート」から「ノート」に変更

### DIFF
--- a/apps/web/features/customer/detail/customer-detail-tabs-skeleton.tsx
+++ b/apps/web/features/customer/detail/customer-detail-tabs-skeleton.tsx
@@ -1,18 +1,25 @@
+import { Tabs, TabsList, TabsTrigger } from "@workspace/ui/components/tabs";
+
 export function CustomerDetailTabsSkeleton() {
-	const tabs = ["基本情報", "レポート"];
+	const tabs = [
+		{ label: "基本情報", value: "basic" },
+		{ label: "ノート", value: "notes" },
+	] as const;
 
 	return (
-		<div className="border-b">
-			<nav className="flex space-x-8">
-				{tabs.map((label) => (
-					<div
-						className="py-4 px-1 border-b-2 border-transparent font-medium text-sm text-muted-foreground opacity-50 pointer-events-none"
-						key={label}
+		<Tabs className="w-full" value="basic">
+			<TabsList className="grid grid-cols-2 bg-muted-foreground/10 w-full">
+				{tabs.map((tab) => (
+					<TabsTrigger
+						className="pointer-events-none opacity-50"
+						disabled
+						key={tab.value}
+						value={tab.value}
 					>
-						{label}
-					</div>
+						{tab.label}
+					</TabsTrigger>
 				))}
-			</nav>
-		</div>
+			</TabsList>
+		</Tabs>
 	);
 }

--- a/apps/web/features/customer/detail/customer-detail-tabs.tsx
+++ b/apps/web/features/customer/detail/customer-detail-tabs.tsx
@@ -22,9 +22,9 @@ export function CustomerDetailTabs({
 			value: "basic",
 		},
 		{
-			href: `/customers/${customerId}/reports`,
-			label: "レポート",
-			value: "reports",
+			href: `/customers/${customerId}/notes`,
+			label: "ノート",
+			value: "notes",
 		},
 	] as const;
 

--- a/apps/web/features/customer/detail/customer-detail-tabs.tsx
+++ b/apps/web/features/customer/detail/customer-detail-tabs.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Tabs, TabsList, TabsTrigger } from "@workspace/ui/components/tabs";
+import type { Route } from "next";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { use } from "react";
@@ -38,7 +39,7 @@ export function CustomerDetailTabs({
 					<TabsTrigger asChild key={tab.value} value={tab.value}>
 						<Link
 							aria-current={activeTab === tab.value ? "page" : undefined}
-							href={tab.href}
+							href={tab.href as Route}
 						>
 							{tab.label}
 						</Link>


### PR DESCRIPTION
## 概要

顧客詳細ページのタブを「レポート」から「ノート」に変更しました。

## 変更内容

- shadcn/ui の `Tabs` コンポーネントを使用してスケルトンコンポーネントを統一
- レポートタブをノートタブに置き換え
  - `/customers/[customerId]/reports` → `/customers/[customerId]/notes`
- タブの構造を配列オブジェクトに変更（`{ label, value }` 形式）


## テスト計画

- [ ] タブの表示が正しいことを確認
- [ ] タブの切り替えが正しく動作することを確認
- [ ] スケルトンの表示が統一されていることを確認
- [ ] ビルドエラーの修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)