### PR TITLE
Supabase Storage 有効化

### DIFF
--- a/packages/supabase/config.toml
+++ b/packages/supabase/config.toml
@@ -108,9 +108,9 @@ file_size_limit = "50MiB"
 
 # Configure local storage buckets
 [storage.buckets.service-note-images]
-public = true
+public = false
 file_size_limit = "10MiB"
-allowed_mime_types = ["image/png", "image/jpeg", "image/jpg", "image/webp", "image/gif"]
+allowed_mime_types = ["image/*"]
 objects_path = "./storage/service-note-images"
 
 [auth]

--- a/packages/supabase/config.toml
+++ b/packages/supabase/config.toml
@@ -98,7 +98,7 @@ port = 62024
 # sender_name = "Admin"
 
 [storage]
-enabled = false
+enabled = true
 # The maximum file size allowed (e.g. "5MB", "500KB").
 file_size_limit = "50MiB"
 
@@ -106,12 +106,12 @@ file_size_limit = "50MiB"
 # [storage.image_transformation]
 # enabled = true
 
-# Uncomment to configure local storage buckets
-# [storage.buckets.images]
-# public = false
-# file_size_limit = "50MiB"
-# allowed_mime_types = ["image/png", "image/jpeg"]
-# objects_path = "./images"
+# Configure local storage buckets
+[storage.buckets.service-note-images]
+public = true
+file_size_limit = "10MiB"
+allowed_mime_types = ["image/png", "image/jpeg", "image/jpg", "image/webp", "image/gif"]
+objects_path = "./storage/service-note-images"
 
 [auth]
 enabled = true


### PR DESCRIPTION
- supabase 設定を更新して storage の有効化
- 顧客ノート用の画像を格納するバケットを設定
  - 格納用のフォルダを作成（作成しておかないと Supabase 起動時にエラーが出るため）