### PR TITLE
顧客ノート検索フォームのハイドレーション処理を修正

### DIFF
--- a/apps/web/features/customer/note/customer-notes-search-form.tsx
+++ b/apps/web/features/customer/note/customer-notes-search-form.tsx
@@ -86,7 +86,7 @@ export function CustomerNotesSearchForm(props: CustomerNotesSearchFormProps) {
 		});
 	}
 
-	const isDisabled = props.disabled || isHydrated;
+	const isDisabled = props.disabled || !isHydrated;
 
 	return (
 		<Collapsible disabled={isDisabled} onOpenChange={setIsOpen} open={isOpen}>


### PR DESCRIPTION
## Summary
- 顧客ノート検索フォームで `isHydrated` が true のときに disabled になっていた問題を修正
- 正しく `isHydrated` が false のとき（ハイドレーション完了前）に disabled になるように変更

## Changes
- `customer-notes-search-form.tsx:89` の条件を `isHydrated` から `!isHydrated` に修正

## Test plan
- [x] バリデーションチェックが通ることを確認（lint, format, 型チェック）
- [ ] ブラウザでハイドレーション前にフォームが disabled になることを確認
- [ ] ハイドレーション後にフォームが操作可能になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)