### PR TITLE
顧客ノート登録機能の実装

### DIFF
--- a/apps/web/app/(private)/customers/[customerId]/@action/default.tsx
+++ b/apps/web/app/(private)/customers/[customerId]/@action/default.tsx
@@ -1,0 +1,3 @@
+export default function ActionSlotDefault() {
+	return null;
+}

--- a/apps/web/app/(private)/customers/[customerId]/@action/notes/page.tsx
+++ b/apps/web/app/(private)/customers/[customerId]/@action/notes/page.tsx
@@ -1,0 +1,23 @@
+import { Button } from "@workspace/ui/components/button";
+import { Plus } from "lucide-react";
+import { Suspense } from "react";
+import { RegisterCustomerNoteDialogContainer } from "../../../../../../features/customer/note/register-customer-note-dialog-container";
+
+export default async function CustomerNoteActionPage({
+	params,
+}: PageProps<"/customers/[customerId]/notes">) {
+	const customerIdPromise = params.then(({ customerId }) => customerId);
+
+	return (
+		<Suspense
+			fallback={
+				<Button disabled>
+					<Plus className="h-4 w-4 mr-2" />
+					ノートを追加
+				</Button>
+			}
+		>
+			<RegisterCustomerNoteDialogContainer customerId={customerIdPromise} />
+		</Suspense>
+	);
+}

--- a/apps/web/app/(private)/customers/[customerId]/layout.tsx
+++ b/apps/web/app/(private)/customers/[customerId]/layout.tsx
@@ -1,20 +1,29 @@
+import type { ReactNode } from "react";
 import { Suspense } from "react";
 import { CustomerDetailTabs } from "../../../../features/customer/detail/customer-detail-tabs";
 import { CustomerDetailTabsSkeleton } from "../../../../features/customer/detail/customer-detail-tabs-skeleton";
 import { CustomerInfoContainer } from "../../../../features/customer/detail/customer-info-container";
 import { CustomerInfoSkeleton } from "../../../../features/customer/detail/customer-info-skeleton";
 
+type CustomerDetailLayoutProps = LayoutProps<"/customers/[customerId]"> & {
+	action: ReactNode;
+};
+
 export default async function CustomerDetailLayout({
 	params,
 	children,
-}: LayoutProps<"/customers/[customerId]">) {
+	action,
+}: CustomerDetailLayoutProps) {
 	const customerIdPromise = params.then(({ customerId }) => customerId);
 
 	return (
 		<div className="container mx-auto p-4 space-y-4">
-			<Suspense fallback={<CustomerInfoSkeleton />}>
-				<CustomerInfoContainer customerIdPromise={customerIdPromise} />
-			</Suspense>
+			<div className="flex items-center justify-between">
+				<Suspense fallback={<CustomerInfoSkeleton />}>
+					<CustomerInfoContainer customerIdPromise={customerIdPromise} />
+				</Suspense>
+				{action}
+			</div>
 
 			<Suspense fallback={<CustomerDetailTabsSkeleton />}>
 				<CustomerDetailTabs customerIdPromise={customerIdPromise} />

--- a/apps/web/e2e/customer-notes.e2e.test.ts
+++ b/apps/web/e2e/customer-notes.e2e.test.ts
@@ -2,8 +2,6 @@ import { test as base, expect, type Page } from "@playwright/test";
 
 type CustomerNotesPageFixture = {
 	customerNotesPage: Page;
-	testUser: { email: string; password: string };
-	testCustomerId: string;
 };
 
 const test = base.extend<CustomerNotesPageFixture>({

--- a/apps/web/e2e/customer-notes.e2e.test.ts
+++ b/apps/web/e2e/customer-notes.e2e.test.ts
@@ -1,0 +1,101 @@
+import { test as base, expect, type Page } from "@playwright/test";
+
+type CustomerNotesPageFixture = {
+	customerNotesPage: Page;
+	testUser: { email: string; password: string };
+	testCustomerId: string;
+};
+
+const test = base.extend<CustomerNotesPageFixture>({
+	customerNotesPage: async ({ page }, use) => {
+		const customerId = "00000000-0000-0000-0000-000000000001";
+		const testUser = {
+			email: "test1@example.com",
+			password: "Test@Pass123",
+		};
+
+		// ログイン
+		await page.goto("/login");
+		await page.getByLabel("メールアドレス").fill(testUser.email);
+		await page
+			.getByRole("textbox", { name: "パスワード" })
+			.fill(testUser.password);
+		await page.getByRole("button", { name: "ログイン" }).click();
+		await page.waitForURL("/");
+
+		// 顧客ノート一覧ページへ遷移
+		await page.goto(`/customers/${customerId}/notes`);
+		await page.waitForURL(`/customers/${customerId}/notes`);
+		await expect(page.getByText("読み込み中")).toBeHidden();
+
+		await use(page);
+	},
+});
+
+test("正常系: 1文字（最小境界値）のノート登録成功", async ({
+	customerNotesPage,
+}) => {
+	const noteContent = "¥";
+
+	await test.step("ノート追加ダイアログを開く", async () => {
+		await customerNotesPage
+			.getByRole("button", { name: "ノートを追加" })
+			.click();
+		await expect(
+			customerNotesPage.getByRole("dialog").getByText("ノートを追加"),
+		).toBeVisible();
+	});
+
+	await test.step("1文字のノート内容を入力", async () => {
+		await customerNotesPage.getByLabel("内容").fill(noteContent);
+	});
+
+	await test.step("ノートを登録", async () => {
+		await customerNotesPage
+			.getByRole("dialog")
+			.getByRole("button", { name: "登録" })
+			.click();
+	});
+
+	await test.step("登録結果を確認", async () => {
+		// ダイアログが閉じることを確認
+		await expect(customerNotesPage.getByRole("dialog")).toBeHidden();
+
+		// 登録したノートが一覧に表示されることを確認
+		await expect(customerNotesPage.getByText(noteContent)).toBeVisible();
+	});
+});
+
+test("正常系: 4096文字（最大境界値）のノート登録成功", async ({
+	customerNotesPage,
+}) => {
+	const noteContent = "あ".repeat(4096);
+
+	await test.step("ノート追加ダイアログを開く", async () => {
+		await customerNotesPage
+			.getByRole("button", { name: "ノートを追加" })
+			.click();
+		await expect(
+			customerNotesPage.getByRole("dialog").getByText("ノートを追加"),
+		).toBeVisible();
+	});
+
+	await test.step("4096文字のノート内容を入力", async () => {
+		await customerNotesPage.getByLabel("内容").fill(noteContent);
+	});
+
+	await test.step("ノートを登録", async () => {
+		await customerNotesPage
+			.getByRole("dialog")
+			.getByRole("button", { name: "登録" })
+			.click();
+	});
+
+	await test.step("登録結果を確認", async () => {
+		// ダイアログが閉じることを確認
+		await expect(customerNotesPage.getByRole("dialog")).toBeHidden();
+
+		// 登録したノートが一覧に表示されることを確認
+		await expect(customerNotesPage.getByText(noteContent)).toBeVisible();
+	});
+});

--- a/apps/web/features/customer/note/register-customer-note-action.small.server.test.ts
+++ b/apps/web/features/customer/note/register-customer-note-action.small.server.test.ts
@@ -1,0 +1,95 @@
+import { expect, test, vi } from "vitest";
+import { registerCustomerNoteAction } from "./register-customer-note-action";
+
+vi.mock("@repo/logger/nextjs/server", () => ({
+	getLogger: vi.fn().mockResolvedValue({
+		error: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+	}),
+}));
+
+test.each([
+	{
+		description: "引数が undefined",
+		input: undefined,
+	},
+	{
+		description: "引数が null",
+		input: null,
+	},
+	{
+		description: "引数が数値",
+		input: 123,
+	},
+	{
+		description: "引数が配列",
+		input: [],
+	},
+	{
+		description: "引数が空オブジェクト",
+		input: {},
+	},
+	{
+		description: "content プロパティが欠けている",
+		input: {
+			customerId: "00000000-0000-0000-0000-000000000001",
+		},
+	},
+	{
+		description: "customerId プロパティが欠けている",
+		input: {
+			content: "テストノート",
+		},
+	},
+	{
+		description: "content が数値",
+		input: {
+			content: 123,
+			customerId: "00000000-0000-0000-0000-000000000001",
+		},
+	},
+	{
+		description: "customerId が数値",
+		input: {
+			content: "テストノート",
+			customerId: 123,
+		},
+	},
+	{
+		description: "content が空文字列",
+		input: {
+			content: "",
+			customerId: "00000000-0000-0000-0000-000000000001",
+		},
+	},
+	{
+		description: "customerId が空文字列",
+		input: {
+			content: "テストノート",
+			customerId: "",
+		},
+	},
+	{
+		description: "customerId がUUID形式でない",
+		input: {
+			content: "テストノート",
+			customerId: "invalid-uuid",
+		},
+	},
+	{
+		description: "content が4097文字（最大値4096を超過）",
+		input: {
+			content: "あ".repeat(4097),
+			customerId: "00000000-0000-0000-0000-000000000001",
+		},
+	},
+])("$description の場合、バリデーションエラーを返す", async ({ input }) => {
+	// @ts-expect-error - サーバーアクションは任意の引数で呼び出される可能性がある
+	const result = await registerCustomerNoteAction(input);
+
+	expect(result.success).toBe(false);
+	if (!result.success) {
+		expect(result.error).toBe("入力内容に誤りがあります");
+	}
+});

--- a/apps/web/features/customer/note/register-customer-note-action.ts
+++ b/apps/web/features/customer/note/register-customer-note-action.ts
@@ -1,0 +1,88 @@
+"use server";
+
+import { fail, type Result, succeed } from "@harusame0616/result";
+import { EventType } from "@repo/logger/event-types";
+import { getLogger } from "@repo/logger/nextjs/server";
+import { db } from "@workspace/db/client";
+import { customerNotesTable } from "@workspace/db/schema/customer-note";
+import { updateTag } from "next/cache";
+import * as v from "valibot";
+import { getUserStaffId } from "../../../lib/auth/get-user-staff-id";
+import { CustomerTag } from "../tag";
+
+const INVALID_INPUT_ERROR_MESSAGE = "入力内容に誤りがあります" as const;
+const UNAUTHORIZED_ERROR_MESSAGE = "認証に失敗しました" as const;
+const INTERNAL_SERVER_ERROR_MESSAGE =
+	"サーバーエラーが発生しました。時間をおいて再度お試しください" as const;
+
+type RegisterCustomerNoteActionErrorMessage =
+	| typeof INVALID_INPUT_ERROR_MESSAGE
+	| typeof UNAUTHORIZED_ERROR_MESSAGE
+	| typeof INTERNAL_SERVER_ERROR_MESSAGE;
+
+const registerCustomerNoteSchema = v.object({
+	content: v.pipe(
+		v.string(),
+		v.minLength(1, "内容を入力してください"),
+		v.maxLength(4096, "内容は4096文字以内で入力してください"),
+	),
+	customerId: v.pipe(v.string(), v.uuid()),
+});
+
+type RegisterCustomerNoteInput = v.InferInput<
+	typeof registerCustomerNoteSchema
+>;
+
+export async function registerCustomerNoteAction(
+	params: RegisterCustomerNoteInput,
+): Promise<Result<undefined, RegisterCustomerNoteActionErrorMessage>> {
+	const logger = await getLogger("registerCustomerNoteAction");
+	logger.info("execute registerCustomerNoteAction", {
+		params,
+	});
+
+	// バリデーション
+	const paramsParseResult = v.safeParse(registerCustomerNoteSchema, params);
+	if (!paramsParseResult.success) {
+		logger.warn("Validation failed", {
+			event: EventType.InputValidationError,
+			issues: paramsParseResult.issues,
+		});
+		return fail(INVALID_INPUT_ERROR_MESSAGE);
+	}
+
+	const { content, customerId } = paramsParseResult.output;
+
+	// 認証情報の取得
+	const staffId = await getUserStaffId();
+	if (!staffId) {
+		logger.warn("Unauthorized access", {
+			event: EventType.AuthenticationFailure,
+		});
+		return fail(UNAUTHORIZED_ERROR_MESSAGE);
+	}
+
+	try {
+		// 顧客ノートの登録
+		await db.insert(customerNotesTable).values({
+			content,
+			customerId,
+			staffId,
+		});
+
+		logger.info("Customer note registered successfully", {
+			action: "register-customer-note",
+			customerId,
+		});
+
+		updateTag(CustomerTag.NoteCrud(customerId));
+	} catch (error) {
+		logger.error("Failed to register customer note", {
+			action: "register-customer-note",
+			err: error,
+		});
+		return fail(INTERNAL_SERVER_ERROR_MESSAGE);
+	}
+
+	return succeed();
+}

--- a/apps/web/features/customer/note/register-customer-note-dialog-container.tsx
+++ b/apps/web/features/customer/note/register-customer-note-dialog-container.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react";
+import { RegisterCustomerNoteDialog } from "./register-customer-note-dialog";
+
+type RegisterCustomerNoteDialogContainerProps = {
+	customerId: Promise<string>;
+};
+
+export async function RegisterCustomerNoteDialogContainer({
+	customerId,
+}: RegisterCustomerNoteDialogContainerProps): Promise<ReactNode> {
+	const resolvedCustomerId = await customerId;
+
+	return <RegisterCustomerNoteDialog customerId={resolvedCustomerId} />;
+}

--- a/apps/web/features/customer/note/register-customer-note-dialog.browser.test.tsx
+++ b/apps/web/features/customer/note/register-customer-note-dialog.browser.test.tsx
@@ -1,0 +1,92 @@
+import type { Mock } from "vitest";
+import { test as base, expect, vi } from "vitest";
+import { page } from "vitest/browser";
+import { render } from "vitest-browser-react";
+import { RegisterCustomerNoteDialog } from "./register-customer-note-dialog";
+
+// Server Actionをモック
+vi.mock("./register-customer-note-action", () => ({
+	registerCustomerNoteAction: vi.fn(),
+}));
+
+const test = base.extend<{
+	registerCustomerNoteActionMock: Mock;
+}>({
+	registerCustomerNoteActionMock: async (
+		// biome-ignore lint/correctness/noEmptyPattern: Vitestのfixtureパターンで使用する標準的な記法
+		{},
+		// biome-ignore lint/suspicious/noExplicitAny: https://github.com/vitest-dev/vitest/discussions/5710
+		use: any,
+	) => {
+		const registerCustomerNoteActionModule = await import(
+			"./register-customer-note-action"
+		);
+		const mock = vi.mocked(
+			registerCustomerNoteActionModule.registerCustomerNoteAction,
+		);
+		await use(mock);
+		vi.clearAllMocks();
+	},
+});
+
+test("内容が空の場合、バリデーションエラーが表示される", async ({
+	registerCustomerNoteActionMock,
+}) => {
+	const testCustomerId = "00000000-0000-0000-0000-000000000001";
+
+	render(<RegisterCustomerNoteDialog customerId={testCustomerId} />);
+
+	// ダイアログを開く
+	await page.getByRole("button", { name: "ノートを追加" }).click();
+
+	// 内容を入力せずに登録ボタンをクリック
+	await page.getByRole("button", { name: "登録" }).click();
+
+	// バリデーションエラーが表示される
+	await expect
+		.element(page.getByText("内容を入力してください"))
+		.toBeInTheDocument();
+
+	// Server Actionが呼ばれないことを確認
+	expect(registerCustomerNoteActionMock).not.toHaveBeenCalled();
+});
+
+test("キャンセルボタンでダイアログが閉じる", async () => {
+	const testCustomerId = "00000000-0000-0000-0000-000000000001";
+
+	render(<RegisterCustomerNoteDialog customerId={testCustomerId} />);
+
+	// ダイアログを開く
+	await page.getByRole("button", { name: "ノートを追加" }).click();
+
+	// 内容を入力
+	await page.getByLabelText("内容").fill("テストノート");
+
+	// キャンセルボタンをクリック
+	await page.getByRole("button", { name: "キャンセル" }).click();
+
+	// ダイアログが閉じることを確認
+	await expect.element(page.getByRole("dialog")).not.toBeInTheDocument();
+});
+
+test("キャンセル後に再度開くとフォームがリセットされている", async () => {
+	const testCustomerId = "00000000-0000-0000-0000-000000000001";
+	const testContent = "テストノート";
+
+	render(<RegisterCustomerNoteDialog customerId={testCustomerId} />);
+
+	// ダイアログを開く
+	await page.getByRole("button", { name: "ノートを追加" }).click();
+
+	// 内容を入力
+	await page.getByLabelText("内容").fill(testContent);
+
+	// キャンセル
+	await page.getByRole("button", { name: "キャンセル" }).click();
+
+	// 再度ダイアログを開く
+	await page.getByRole("button", { name: "ノートを追加" }).click();
+
+	// 入力フィールドが空であることを確認
+	await expect.element(page.getByLabelText("内容")).toHaveValue("");
+});

--- a/apps/web/features/customer/note/register-customer-note-dialog.tsx
+++ b/apps/web/features/customer/note/register-customer-note-dialog.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { valibotResolver } from "@hookform/resolvers/valibot";
+import { Button } from "@workspace/ui/components/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@workspace/ui/components/dialog";
+import {
+	Form,
+	FormControl,
+	FormDescription,
+	FormField,
+	FormItem,
+	FormLabel,
+	FormMessage,
+} from "@workspace/ui/components/form";
+import { Textarea } from "@workspace/ui/components/textarea";
+import { AlertCircle, Loader2, Plus } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import { useForm } from "react-hook-form";
+import * as v from "valibot";
+import { registerCustomerNoteAction } from "./register-customer-note-action";
+
+const formSchema = v.object({
+	content: v.pipe(
+		v.string(),
+		v.minLength(1, "内容を入力してください"),
+		v.maxLength(4096, "内容は4096文字以内で入力してください"),
+	),
+});
+
+type FormValues = v.InferOutput<typeof formSchema>;
+
+type RegisterCustomerNoteDialogProps = {
+	customerId: string;
+};
+
+export function RegisterCustomerNoteDialog({
+	customerId,
+}: RegisterCustomerNoteDialogProps) {
+	const router = useRouter();
+	const [open, setOpen] = useState(false);
+	const [isPending, startTransition] = useTransition();
+	const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+	const form = useForm<FormValues>({
+		defaultValues: {
+			content: "",
+		},
+		resolver: valibotResolver(formSchema),
+	});
+
+	function onSubmit(values: FormValues) {
+		setErrorMessage(null);
+
+		startTransition(async () => {
+			const result = await registerCustomerNoteAction({
+				content: values.content,
+				customerId,
+			});
+
+			if (!result.success) {
+				setErrorMessage(result.error);
+				return;
+			}
+
+			form.reset();
+			setErrorMessage(null);
+			setOpen(false);
+			router.refresh();
+		});
+	}
+
+	function handleOpenChange(open: boolean) {
+		if (!open) {
+			form.reset();
+			setErrorMessage(null);
+		}
+		setOpen(open);
+	}
+
+	return (
+		<Dialog onOpenChange={handleOpenChange} open={open}>
+			<DialogTrigger asChild>
+				<Button>
+					<Plus className="h-4 w-4 mr-2" />
+					ノートを追加
+				</Button>
+			</DialogTrigger>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>ノートを追加</DialogTitle>
+				</DialogHeader>
+
+				<Form {...form}>
+					<form className="space-y-4" onSubmit={form.handleSubmit(onSubmit)}>
+						{errorMessage && (
+							<div className="flex items-center gap-2 p-3 text-sm text-destructive bg-destructive/10 rounded-md">
+								<AlertCircle className="h-4 w-4 shrink-0" />
+								<p>{errorMessage}</p>
+							</div>
+						)}
+
+						<FormField
+							control={form.control}
+							name="content"
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>内容</FormLabel>
+									<FormDescription>
+										顧客に関するメモや連絡事項を記録できます
+									</FormDescription>
+									<FormControl>
+										<Textarea
+											{...field}
+											className="max-h-32"
+											disabled={isPending}
+											maxLength={4096}
+										/>
+									</FormControl>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
+
+						<DialogFooter>
+							<Button
+								disabled={isPending}
+								onClick={() => handleOpenChange(false)}
+								type="button"
+								variant="outline"
+							>
+								キャンセル
+							</Button>
+							<Button
+								className="min-w-[120]"
+								disabled={isPending}
+								type="submit"
+							>
+								{isPending ? (
+									<>
+										登録中
+										<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+									</>
+								) : (
+									"登録"
+								)}
+							</Button>
+						</DialogFooter>
+					</form>
+				</Form>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/web/features/customer/note/register-customer-note-dialog.tsx
+++ b/apps/web/features/customer/note/register-customer-note-dialog.tsx
@@ -146,7 +146,7 @@ export function RegisterCustomerNoteDialog({
 								{isPending ? (
 									<>
 										登録中
-										<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+										<Loader2 className="ml-2 size-4 animate-spin" />
 									</>
 								) : (
 									"登録"

--- a/packages/ui/src/components/textarea.tsx
+++ b/packages/ui/src/components/textarea.tsx
@@ -5,7 +5,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
 	return (
 		<textarea
 			className={cn(
-				"border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-s overflow-scroll break-all",
+				"border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-s break-all overflow-auto",
 				className,
 			)}
 			data-slot="textarea"

--- a/packages/ui/src/components/textarea.tsx
+++ b/packages/ui/src/components/textarea.tsx
@@ -5,7 +5,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
 	return (
 		<textarea
 			className={cn(
-				"border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+				"border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-s overflow-scroll break-all",
 				className,
 			)}
 			data-slot="textarea"

--- a/packages/ui/src/components/textarea.tsx
+++ b/packages/ui/src/components/textarea.tsx
@@ -5,7 +5,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
 	return (
 		<textarea
 			className={cn(
-				"border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-s break-all overflow-auto",
+				"border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm break-all overflow-auto",
 				className,
 			)}
 			data-slot="textarea"


### PR DESCRIPTION
## Summary
- 顧客ノート登録ダイアログの実装
- Server Actionによる顧客ノート登録処理の実装
- バリデーション処理の実装（入力必須、最大4096文字）
- E2Eテスト、ブラウザテスト、Smallテストの追加

## Test plan
- [ ] E2Eテストが成功することを確認
- [ ] ブラウザテストが成功することを確認
- [ ] Smallテストが成功することを確認
- [ ] デプロイが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)