### PR TITLE
顧客ノート編集機能の実装

### DIFF
--- a/apps/web/e2e/customer-note-edit.e2e.test.ts
+++ b/apps/web/e2e/customer-note-edit.e2e.test.ts
@@ -1,0 +1,193 @@
+import { randomUUID } from "node:crypto";
+import { expect, test } from "@playwright/test";
+
+test("作成した本人が編集できる", async ({ page }) => {
+	const customerId = "00000000-0000-0000-0000-000000000001";
+	const testUser = {
+		email: "test1@example.com",
+		password: "Test@Pass123",
+	};
+	const noteContent = `編集テスト用ノート (${randomUUID()})`;
+	const editedContent = `編集後のノート (${randomUUID()})`;
+
+	await test.step("ログイン", async () => {
+		await page.goto("/login");
+		await page.getByLabel("メールアドレス").fill(testUser.email);
+		await page
+			.getByRole("textbox", { name: "パスワード" })
+			.fill(testUser.password);
+		await page.getByRole("button", { name: "ログイン" }).click();
+		await page.waitForURL("/");
+	});
+
+	await test.step("顧客ノート一覧ページへ遷移", async () => {
+		await page.goto(`/customers/${customerId}/notes`);
+		await page.waitForURL(`/customers/${customerId}/notes`);
+		await expect(page.getByText("読み込み中")).toBeHidden();
+	});
+
+	await test.step("ノート作成", async () => {
+		await page.getByRole("button", { name: "ノートを追加" }).click();
+		await expect(
+			page.getByRole("dialog").getByText("ノートを追加"),
+		).toBeVisible();
+
+		await page.getByLabel("内容").fill(noteContent);
+
+		await page
+			.getByRole("dialog")
+			.getByRole("button", { name: "登録" })
+			.click();
+
+		// ダイアログが閉じることを確認
+		await expect(page.getByRole("dialog")).toBeHidden();
+
+		// 登録したノートが一覧に表示されることを確認
+		await expect(page.getByText(noteContent)).toBeVisible();
+	});
+
+	await test.step("編集ボタンをクリック", async () => {
+		const noteCard = page.getByRole("listitem").filter({
+			has: page.getByText(noteContent),
+		});
+
+		await noteCard.getByRole("button", { name: "編集" }).click();
+
+		// 編集ダイアログが表示されることを確認
+		const dialog = page.getByRole("dialog");
+		await expect(
+			dialog.getByRole("heading", { name: "ノートを編集" }),
+		).toBeVisible();
+
+		// 既存の内容が入力されていることを確認
+		await expect(dialog.getByLabel("内容")).toHaveValue(noteContent);
+	});
+
+	await test.step("内容を編集して更新", async () => {
+		const dialog = page.getByRole("dialog");
+		await dialog.getByLabel("内容").fill(editedContent);
+		await dialog.getByRole("button", { name: "更新" }).click();
+
+		// ダイアログが閉じることを確認
+		await expect(dialog).toBeHidden();
+	});
+
+	await test.step("編集内容が反映されることを確認", async () => {
+		// 編集後の内容が一覧に表示されることを確認
+		await expect(page.getByText(editedContent)).toBeVisible();
+
+		// 元の内容が表示されないことを確認
+		await expect(page.getByText(noteContent)).toBeHidden();
+	});
+});
+
+test("管理者が他人のノートを編集できる", async ({ browser }) => {
+	const customerId = "00000000-0000-0000-0000-000000000001";
+	const testUser = {
+		email: "test1@example.com",
+		password: "Test@Pass123",
+	};
+	const adminUser = {
+		email: "admin@example.com",
+		password: "Admin@789!",
+	};
+	const noteContent = `管理者編集テスト用ノート (${randomUUID()})`;
+	const editedContent = `管理者が編集したノート (${randomUUID()})`;
+
+	// test1 ユーザーでノート作成
+	const userContext = await browser.newContext();
+	const userPage = await userContext.newPage();
+
+	await test.step("test1 でログイン", async () => {
+		await userPage.goto("/login");
+		await userPage.getByLabel("メールアドレス").fill(testUser.email);
+		await userPage
+			.getByRole("textbox", { name: "パスワード" })
+			.fill(testUser.password);
+		await userPage.getByRole("button", { name: "ログイン" }).click();
+		await userPage.waitForURL("/");
+	});
+
+	await test.step("test1 で顧客ノート一覧ページへ遷移", async () => {
+		await userPage.goto(`/customers/${customerId}/notes`);
+		await userPage.waitForURL(`/customers/${customerId}/notes`);
+		await expect(userPage.getByText("読み込み中")).toBeHidden();
+	});
+
+	await test.step("test1 でノート作成", async () => {
+		await userPage.getByRole("button", { name: "ノートを追加" }).click();
+		await expect(
+			userPage.getByRole("dialog").getByText("ノートを追加"),
+		).toBeVisible();
+
+		await userPage.getByLabel("内容").fill(noteContent);
+
+		await userPage
+			.getByRole("dialog")
+			.getByRole("button", { name: "登録" })
+			.click();
+
+		// ダイアログが閉じることを確認
+		await expect(userPage.getByRole("dialog")).toBeHidden();
+
+		// 登録したノートが一覧に表示されることを確認
+		await expect(userPage.getByText(noteContent)).toBeVisible();
+	});
+
+	await userContext.close();
+
+	// admin ユーザーで編集
+	const adminContext = await browser.newContext();
+	const adminPage = await adminContext.newPage();
+
+	await test.step("admin でログイン", async () => {
+		await adminPage.goto("/login");
+		await adminPage.getByLabel("メールアドレス").fill(adminUser.email);
+		await adminPage
+			.getByRole("textbox", { name: "パスワード" })
+			.fill(adminUser.password);
+		await adminPage.getByRole("button", { name: "ログイン" }).click();
+		await adminPage.waitForURL("/");
+	});
+
+	await test.step("admin で顧客ノート一覧ページへ遷移", async () => {
+		await adminPage.goto(`/customers/${customerId}/notes`);
+		await adminPage.waitForURL(`/customers/${customerId}/notes`);
+		await expect(adminPage.getByText("読み込み中")).toBeHidden();
+	});
+
+	await test.step("admin で test1 が作成したノートを編集", async () => {
+		const noteCard = adminPage.getByRole("listitem").filter({
+			has: adminPage.getByText(noteContent),
+		});
+
+		// 編集ボタンが表示されることを確認
+		const editButton = noteCard.getByRole("button", { name: "編集" });
+		await expect(editButton).toBeVisible();
+
+		await editButton.click();
+
+		// 編集ダイアログが表示されることを確認
+		const dialog = adminPage.getByRole("dialog");
+		await expect(
+			dialog.getByRole("heading", { name: "ノートを編集" }),
+		).toBeVisible();
+
+		// 内容を編集
+		await dialog.getByLabel("内容").fill(editedContent);
+		await dialog.getByRole("button", { name: "更新" }).click();
+
+		// ダイアログが閉じることを確認
+		await expect(dialog).toBeHidden();
+	});
+
+	await test.step("編集内容が反映されることを確認", async () => {
+		// 編集後の内容が一覧に表示されることを確認
+		await expect(adminPage.getByText(editedContent)).toBeVisible();
+
+		// 元の内容が表示されないことを確認
+		await expect(adminPage.getByText(noteContent)).toBeHidden();
+	});
+
+	await adminContext.close();
+});

--- a/apps/web/features/customer/note/customer-note-card.tsx
+++ b/apps/web/features/customer/note/customer-note-card.tsx
@@ -1,9 +1,9 @@
-import { Button } from "@workspace/ui/components/button";
 import { Card, CardContent, CardHeader } from "@workspace/ui/components/card";
-import { CalendarClock, Edit, UserPen } from "lucide-react";
+import { CalendarClock, UserPen } from "lucide-react";
 import { DateTime } from "../../../components/date-time";
 import { CustomerNoteImageGallery } from "./customer-note-image-gallery";
 import { DeleteCustomerNoteDialog } from "./delete-customer-note-dialog";
+import { EditCustomerNoteDialog } from "./edit-customer-note-dialog";
 import type { CustomerNoteWithImages } from "./get-customer-notes";
 
 type CustomerNoteCardProps = {
@@ -33,10 +33,16 @@ export function CustomerNoteCard({
 
 				{canEdit && (
 					<div className="flex gap-2">
-						<Button size="sm" type="button" variant="outline">
-							<Edit className="h-4 w-4 mr-1" />
-							編集
-						</Button>
+						<EditCustomerNoteDialog
+							customerId={note.customerId}
+							initialContent={note.content}
+							initialImages={note.images}
+							// 古い state が残ってしまい、編集後に再度ダイアログを開いたときに新しい状態にならないため、
+							// updatedAt をキーにして変更があった際にコンポーネントを再マウントさせる
+							// updatedAt.getTime() は UNIX タイムスタンプでタイムゾーン非依存のためハイドレーションエラーなし
+							key={note.updatedAt.getTime()}
+							noteId={note.id}
+						/>
 						<DeleteCustomerNoteDialog noteId={note.id} />
 					</div>
 				)}

--- a/apps/web/features/customer/note/edit-customer-note-action.ts
+++ b/apps/web/features/customer/note/edit-customer-note-action.ts
@@ -1,0 +1,95 @@
+"use server";
+
+import { fail, type Result, succeed } from "@harusame0616/result";
+import { EventType } from "@repo/logger/event-types";
+import { getLogger } from "@repo/logger/nextjs/server";
+import { updateTag } from "next/cache";
+import * as v from "valibot";
+import { getUserRole } from "../../../lib/auth/get-user-role";
+import { getUserStaffId } from "../../../lib/auth/get-user-staff-id";
+import { CustomerTag } from "../tag";
+import { editCustomerNote } from "./edit-customer-note";
+
+const INVALID_INPUT_ERROR_MESSAGE = "入力内容に誤りがあります" as const;
+const UNAUTHORIZED_ERROR_MESSAGE = "認証に失敗しました" as const;
+const FORBIDDEN_ERROR_MESSAGE = "この操作を実行する権限がありません" as const;
+const NOTE_NOT_FOUND_ERROR_MESSAGE =
+	"指定されたノートが見つかりません" as const;
+const INTERNAL_SERVER_ERROR_MESSAGE =
+	"サーバーエラーが発生しました。時間をおいて再度お試しください" as const;
+
+type EditCustomerNoteActionErrorMessage =
+	| typeof INVALID_INPUT_ERROR_MESSAGE
+	| typeof UNAUTHORIZED_ERROR_MESSAGE
+	| typeof FORBIDDEN_ERROR_MESSAGE
+	| typeof NOTE_NOT_FOUND_ERROR_MESSAGE
+	| typeof INTERNAL_SERVER_ERROR_MESSAGE;
+
+const uploadImageSchema = v.object({
+	permanentPath: v.string(),
+	temporaryPath: v.string(),
+});
+
+const editCustomerNoteSchema = v.object({
+	content: v.pipe(
+		v.string(),
+		v.minLength(1, "内容を入力してください"),
+		v.maxLength(4096, "内容は4096文字以内で入力してください"),
+	),
+	keepImagePaths: v.optional(v.array(v.string()), []),
+	noteId: v.pipe(v.string(), v.uuid()),
+	uploadImages: v.optional(v.array(uploadImageSchema), []),
+});
+
+type EditCustomerNoteInput = v.InferInput<typeof editCustomerNoteSchema>;
+
+export async function editCustomerNoteAction(
+	params: EditCustomerNoteInput,
+): Promise<Result<undefined, EditCustomerNoteActionErrorMessage>> {
+	const logger = await getLogger("editCustomerNoteAction");
+	logger.info("editCustomerNoteAction を実行", {
+		params,
+	});
+
+	// バリデーション
+	const paramsParseResult = v.safeParse(editCustomerNoteSchema, params);
+	if (!paramsParseResult.success) {
+		logger.warn("バリデーション失敗", {
+			event: EventType.InputValidationError,
+			issues: paramsParseResult.issues,
+		});
+		return fail(INVALID_INPUT_ERROR_MESSAGE);
+	}
+
+	const { content, noteId, uploadImages, keepImagePaths } =
+		paramsParseResult.output;
+
+	// 認証情報の取得
+	const userId = await getUserStaffId();
+	if (!userId) {
+		logger.warn("認証されていないアクセス", {
+			event: EventType.AuthenticationFailure,
+		});
+		return fail(UNAUTHORIZED_ERROR_MESSAGE);
+	}
+
+	const role = await getUserRole();
+
+	// 編集処理を実行
+	const result = await editCustomerNote({
+		content,
+		customerNoteId: noteId,
+		keepImagePaths,
+		uploadImages,
+		user: { role, userId },
+	});
+
+	if (!result.success) {
+		return result;
+	}
+
+	// キャッシュの更新
+	updateTag(CustomerTag.NoteCrud(result.data.customerId));
+
+	return succeed();
+}

--- a/apps/web/features/customer/note/edit-customer-note.medium.server.test.ts
+++ b/apps/web/features/customer/note/edit-customer-note.medium.server.test.ts
@@ -1,0 +1,33 @@
+import { expect, test, vi } from "vitest";
+import { UserRole } from "../../../lib/auth/get-user-role";
+import { editCustomerNote } from "./edit-customer-note";
+
+// Loggerをモック
+vi.mock("@repo/logger/nextjs/server", () => ({
+	getLogger: vi.fn().mockResolvedValue({
+		error: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+	}),
+}));
+
+test("管理者ではない別ユーザーが他人のノートを編集しようとした場合にエラーが返される", async () => {
+	// seed データの最初のノート（staffId: 00000000-0000-0000-0000-000000000001 が作成）
+	const noteId = "10000000-0000-0000-0000-000000000001";
+
+	// 別ユーザー（staffId: 00000000-0000-0000-0000-000000000002）で編集を試みる
+	const result = await editCustomerNote({
+		content: "編集後の内容",
+		customerNoteId: noteId,
+		uploadImages: [],
+		user: {
+			role: UserRole.User,
+			userId: "00000000-0000-0000-0000-000000000002",
+		},
+	});
+
+	expect(result.success).toBe(false);
+	if (!result.success) {
+		expect(result.error).toBe("この操作を実行する権限がありません");
+	}
+});

--- a/apps/web/features/customer/note/edit-customer-note.ts
+++ b/apps/web/features/customer/note/edit-customer-note.ts
@@ -1,0 +1,189 @@
+import { fail, type Result, succeed } from "@harusame0616/result";
+import { EventType } from "@repo/logger/event-types";
+import { getLogger } from "@repo/logger/nextjs/server";
+import { createAdminClient } from "@repo/supabase/admin";
+import { db } from "@workspace/db/client";
+import {
+	customerNoteImagesTable,
+	customerNotesTable,
+} from "@workspace/db/schema/customer-note";
+import { eq } from "drizzle-orm";
+import { UserRole } from "../../../lib/auth/get-user-role";
+
+const FORBIDDEN_ERROR_MESSAGE = "この操作を実行する権限がありません" as const;
+const NOTE_NOT_FOUND_ERROR_MESSAGE =
+	"指定されたノートが見つかりません" as const;
+const INTERNAL_SERVER_ERROR_MESSAGE =
+	"サーバーエラーが発生しました。時間をおいて再度お試しください" as const;
+
+type EditCustomerNoteErrorMessage =
+	| typeof FORBIDDEN_ERROR_MESSAGE
+	| typeof NOTE_NOT_FOUND_ERROR_MESSAGE
+	| typeof INTERNAL_SERVER_ERROR_MESSAGE;
+
+const BUCKET_NAME = "customer-note-attachments";
+
+type UploadImage = {
+	permanentPath: string;
+	temporaryPath: string;
+};
+
+type EditCustomerNoteInput = {
+	customerNoteId: string;
+	content: string;
+	uploadImages: UploadImage[];
+	keepImagePaths: string[]; // 保持する既存画像のパス
+	user: {
+		role: UserRole;
+		userId: string;
+	};
+};
+
+type EditCustomerNoteSuccess = {
+	customerId: string;
+};
+
+export async function editCustomerNote(
+	input: EditCustomerNoteInput,
+): Promise<Result<EditCustomerNoteSuccess, EditCustomerNoteErrorMessage>> {
+	const logger = await getLogger("editCustomerNote");
+	const { customerNoteId, content, uploadImages, keepImagePaths, user } = input;
+
+	try {
+		// ノートの取得と認可チェック
+		const note = await db.query.customerNotesTable.findFirst({
+			where: eq(customerNotesTable.id, customerNoteId),
+		});
+
+		if (!note) {
+			logger.warn("ノートが見つかりません", {
+				noteId: customerNoteId,
+			});
+			return fail(NOTE_NOT_FOUND_ERROR_MESSAGE);
+		}
+
+		// 作成者チェック
+		if (note.staffId !== user.userId && user.role !== UserRole.Admin) {
+			logger.warn("権限がないアクセス", {
+				event: EventType.AuthorizationError,
+				noteId: customerNoteId,
+				noteStaffId: note.staffId,
+				requestStaffId: user.userId,
+			});
+			return fail(FORBIDDEN_ERROR_MESSAGE);
+		}
+
+		const supabase = createAdminClient();
+
+		// 既存画像の取得
+		const existingImages = await db
+			.select({
+				displayOrder: customerNoteImagesTable.displayOrder,
+				path: customerNoteImagesTable.path,
+			})
+			.from(customerNoteImagesTable)
+			.where(eq(customerNoteImagesTable.customerNoteId, customerNoteId));
+
+		// 削除対象の画像（keepImagePathsに含まれていない画像）
+		const imagesToDelete = existingImages.filter(
+			(img) => !keepImagePaths.includes(img.path),
+		);
+
+		// 保持する既存画像
+		const imagesToKeep = existingImages.filter((img) =>
+			keepImagePaths.includes(img.path),
+		);
+
+		let allImages: { path: string }[] = [];
+
+		await db.transaction(async (tx) => {
+			// ノート内容の更新
+			await tx
+				.update(customerNotesTable)
+				.set({
+					content,
+					updatedAt: new Date(),
+				})
+				.where(eq(customerNotesTable.id, customerNoteId));
+
+			// 既存の画像レコードを全て削除
+			await tx
+				.delete(customerNoteImagesTable)
+				.where(eq(customerNoteImagesTable.customerNoteId, customerNoteId));
+
+			// 新しい画像を並列で移動
+			const newImageResults = await Promise.all(
+				uploadImages.map(async (uploadImage) => {
+					const { permanentPath, temporaryPath } = uploadImage;
+
+					const { error: moveError } = await supabase.storage
+						.from(BUCKET_NAME)
+						.move(temporaryPath, permanentPath);
+
+					if (moveError) {
+						logger.error("Failed to move image file", {
+							err: moveError,
+							permanentPath,
+							temporaryPath,
+						});
+						throw new Error(`Failed to move image file: ${moveError.message}`);
+					}
+
+					return {
+						path: permanentPath,
+					};
+				}),
+			);
+
+			// 保持する既存画像と新規画像を結合してdisplayOrderを再設定
+			allImages = [
+				...imagesToKeep.map((img) => ({ path: img.path })),
+				...newImageResults,
+			];
+
+			// 全ての画像情報をまとめてDB保存
+			if (allImages.length > 0) {
+				await tx.insert(customerNoteImagesTable).values(
+					allImages.map((img, index) => ({
+						customerNoteId,
+						displayOrder: index,
+						path: img.path,
+					})),
+				);
+			}
+		});
+
+		// Supabase Storage から削除対象の画像ファイルを削除（並列処理）
+		if (imagesToDelete.length > 0) {
+			await Promise.allSettled(
+				imagesToDelete.map(async (image) => {
+					const { error } = await supabase.storage
+						.from(BUCKET_NAME)
+						.remove([image.path]);
+
+					if (error) {
+						logger.error("画像ファイルの削除に失敗", {
+							err: error,
+							path: image.path,
+						});
+					}
+				}),
+			);
+		}
+
+		logger.info("顧客ノートの編集に成功", {
+			action: "edit-customer-note",
+			customerId: note.customerId,
+			imageCount: allImages.length,
+			noteId: customerNoteId,
+		});
+
+		return succeed({ customerId: note.customerId });
+	} catch (error) {
+		logger.error("顧客ノートの編集に失敗", {
+			action: "edit-customer-note",
+			err: error,
+		});
+		return fail(INTERNAL_SERVER_ERROR_MESSAGE);
+	}
+}


### PR DESCRIPTION
## 概要
顧客ノートの編集機能を実装しました。

## 実装内容

### 1. 編集機能の実装
- `edit-customer-note.ts`: ビジネスロジック
- `edit-customer-note-action.ts`: Server Action
- `edit-customer-note-dialog.tsx`: 編集ダイアログUI
- 既存画像の保持と個別削除機能
- 新規画像の追加機能（最大5枚）

### 2. 権限管理
- 作成者本人と管理者のみが編集可能
- `edit-customer-note.medium.server.test.ts`: 権限チェックのテスト

### 3. 画像表示問題の修正
- **問題**: 編集直後に再度ダイアログを開いても最新の画像が表示されない
- **原因**: React の key が更新されず、コンポーネントが再マウントされない
- **解決**: key を `note.updatedAt.getTime()` に変更
  - ノート編集時に DB レベルで自動更新される
  - UNIX タイムスタンプでタイムゾーン非依存（ハイドレーションエラーなし）
  - Signed URL の変動リスクを排除

### 4. テスト
- `customer-note-edit.e2e.test.ts`: E2Eテスト
  - 作成者による編集
  - 管理者による他人のノート編集

## テスト実施状況
- ✅ `pnpm validate:check` - すべてパス
- ✅ E2Eテスト実装済み
- ✅ Medium テスト実装済み

## 動作確認項目
- [x] ノートの内容編集
- [x] 既存画像の保持
- [x] 既存画像の個別削除
- [x] 新規画像の追加
- [x] 画像枚数制限（最大5枚）のバリデーション
- [x] 編集直後の画像表示
- [x] 権限チェック（作成者・管理者のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)