### PR TITLE
refactor: useIsHydratedをuseSyncExternalStoreで実装

### DIFF
--- a/apps/web/libs/use-is-hydrated.ts
+++ b/apps/web/libs/use-is-hydrated.ts
@@ -1,25 +1,23 @@
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
 
+/**
+ * ハイドレーション完了を検知するためのフック
+ *
+ * useSyncExternalStoreを使用する理由:
+ * - サーバーとクライアントで異なる値を安全に扱える設計
+ * - React 18以降でハイドレーション状態を扱う推奨パターン
+ * - StrictModeでの安定性が高い
+ * - 値が変更されない外部状態(ブラウザ環境)の場合、空のsubscribe関数は正当な使用法
+ */
 export function useIsHydrated() {
-	const [isHydrated, setIsHydrated] = useState(false);
-
-	/**
-	 * ハイドレーション完了を検知するためのEffect
-	 *
-	 * 検討した代替案: useSyncExternalStore
-	 * - useSyncExternalStoreは外部ストアとの同期が本来の目的であり、
-	 *   subscribeすべき外部の変更源が存在しない今回のケースでは設計思想に反する
-	 * - useEffectは厳密には副作用用だが、「クライアント側でのみ実行」という目的で
-	 *   使用するのはReactコミュニティで広く受け入れられているパターン
-	 *
-	 * 最終決定: useEffectを採用
-	 * - コードの意図が明確で保守しやすい
-	 * - 空のsubscribe関数を渡すAPIの誤用を避けられる
-	 * - パフォーマンス差(1回の再レンダー)は実用上無視できる
-	 */
-	useEffect(() => {
-		setIsHydrated(true);
-	}, []);
+	const isHydrated = useSyncExternalStore(
+		// subscribe: 値が変更されないため空の関数を返す
+		() => () => {},
+		// getSnapshot: クライアント側では常にtrue
+		() => true,
+		// getServerSnapshot: サーバー側では常にfalse
+		() => false,
+	);
 
 	return { isHydrated };
 }

--- a/cspell.json
+++ b/cspell.json
@@ -5,7 +5,8 @@
 		"pnpm-lock.yaml",
 		"packages/supabase/config.toml",
 		"**/playwright-report/**",
-		"packages/db/drizzle/meta/_journal.json"
+		"packages/db/drizzle/meta/_journal.json",
+		"**/test-results/**"
 	],
 	"language": "en",
 	"version": "0.2",


### PR DESCRIPTION
$(cat <<'EOF'
## 概要

`useIsHydrated`フックの実装を`useEffect`から`useSyncExternalStore`に変更しました。

## 変更内容

- `useIsHydrated`の実装を`useSyncExternalStore`ベースに書き直し
- コメントを更新し、`useSyncExternalStore`を採用する理由を明記
- `cspell.json`に`**/test-results/**`を追加してスペルチェック対象から除外

## 変更理由

### useSyncExternalStoreが適切な理由

1. **ハイドレーションミスマッチの安全な処理**: サーバーとクライアントで異なる値を返すケースを安全に扱える設計
2. **React 18以降の推奨パターン**: ハイドレーション状態の検知は「外部ストア(ブラウザ環境)」との同期であり、`useSyncExternalStore`の正当なユースケース
3. **空のsubscribeは正当な使用法**: 値が変更されない外部状態の場合、空の`subscribe`関数は正当な使用法(React公式ドキュメントでも言及)
4. **StrictModeでの安定性向上**: `useEffect`ベースだとStrictModeで2回レンダリングされる可能性があるが、`useSyncExternalStore`はより安定

## API互換性

既存の使用箇所はすべて互換性があります:
- 返り値: `{ isHydrated }`のインターフェースを維持
- 動作: SSR時は`false`、クライアントハイドレーション後は`true`

## テスト

- 型チェック: ✅ パス
- Lint/Format: ✅ パス
- 既存の使用箇所: 4ファイルで使用中、すべて互換性あり

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)