### PR TITLE
feat: 顧客削除機能の実装

### DIFF
--- a/apps/web/app/(private)/customers/[customerId]/@action/page.tsx
+++ b/apps/web/app/(private)/customers/[customerId]/@action/page.tsx
@@ -1,12 +1,14 @@
 import { Skeleton } from "@workspace/ui/components/skeleton";
 import Link from "next/link";
 import { Suspense } from "react";
+import { getUserRole, UserRole } from "@/features/auth/get-user-role";
+import { DeleteCustomerDialog } from "@/features/customer/delete/delete-customer-dialog";
 
 export default function Page({ params }: PageProps<"/customers/[customerId]">) {
 	const customerIdPromise = params.then(({ customerId }) => customerId);
 
 	return (
-		<Suspense fallback={<Skeleton className="h-4 w-10 bg-black/10" />}>
+		<Suspense fallback={<Skeleton className="h-4 w-20 bg-black/10" />}>
 			<Action customerIdPromise={customerIdPromise} />
 		</Suspense>
 	);
@@ -17,12 +19,19 @@ async function Action({
 }: {
 	customerIdPromise: Promise<string>;
 }) {
+	const customerId = await customerIdPromise;
+	const userRole = await getUserRole();
+	const isAdmin = userRole === UserRole.Admin;
+
 	return (
-		<Link
-			className="text-primary underline flex items-center gap-1"
-			href={`/customers/${await customerIdPromise}/edit`}
-		>
-			編集
-		</Link>
+		<div className="flex items-center gap-2">
+			<Link
+				className="text-primary underline flex items-center gap-1"
+				href={`/customers/${customerId}/edit`}
+			>
+				編集
+			</Link>
+			{isAdmin && <DeleteCustomerDialog customerId={customerId} />}
+		</div>
 	);
 }

--- a/apps/web/e2e/customer-delete.e2e.test.ts
+++ b/apps/web/e2e/customer-delete.e2e.test.ts
@@ -1,0 +1,123 @@
+import { test as base, expect } from "@playwright/test";
+import { db } from "@workspace/db/client";
+import { customersTable } from "@workspace/db/schema/customer";
+import { eq } from "drizzle-orm";
+import { v4 } from "uuid";
+
+const test = base.extend<{
+	customer: {
+		customerId: string;
+		email: string;
+		name: string;
+		phone: string;
+	};
+}>({
+	// biome-ignore lint/correctness/noEmptyPattern: The first argument inside a fixture must use object destructuring pattern, e.g. ({ test } => {}). Instead, received "_".
+	async customer({}, use) {
+		const customer = {
+			customerId: v4(),
+			email: `${v4()}@example.com`,
+			name: v4().slice(0, 24),
+			phone: `${Math.floor(Math.random() * 1000000000)}`,
+		};
+
+		await db.insert(customersTable).values(customer);
+		await use(customer);
+		await db
+			.delete(customersTable)
+			.where(eq(customersTable.customerId, customer.customerId));
+	},
+});
+
+test("管理者が顧客を削除できる", async ({ page, customer }) => {
+	const adminUser = {
+		email: "admin@example.com",
+		password: "Admin@789!",
+	};
+
+	await test.step("管理者でログイン", async () => {
+		await page.goto("/login");
+		await page.getByLabel("メールアドレス").fill(adminUser.email);
+		await page
+			.getByRole("textbox", { name: "パスワード" })
+			.fill(adminUser.password);
+		await page.getByRole("button", { name: "ログイン" }).click();
+		await page.waitForURL("/");
+	});
+
+	await test.step("顧客詳細ページに遷移", async () => {
+		await page.goto(`/customers/${customer.customerId}`);
+		await page.waitForURL(`/customers/${customer.customerId}`);
+	});
+
+	await test.step("顧客詳細ページで削除ボタンをクリック", async () => {
+		// 削除ボタンが表示されることを確認
+		const deleteButton = page.getByRole("button", { name: "削除" });
+		await expect(deleteButton).toBeVisible();
+
+		await deleteButton.click();
+
+		// 削除確認ダイアログが表示されることを確認
+		const dialog = page.getByRole("dialog");
+		await expect(
+			dialog.getByRole("heading", { name: "顧客を削除" }),
+		).toBeVisible();
+		await expect(
+			dialog.getByText(
+				"この顧客を削除してもよろしいですか？関連するすべてのノートと画像も削除されます。この操作は取り消せません。",
+			),
+		).toBeVisible();
+	});
+
+	await test.step("確認ダイアログで削除を実行", async () => {
+		const dialog = page.getByRole("dialog");
+		await dialog.getByRole("button", { name: "削除" }).click();
+
+		// ダイアログが閉じることを確認
+		await expect(dialog).toBeHidden();
+
+		// 顧客一覧ページにリダイレクトされることを確認
+		await page.waitForURL("/customers");
+	});
+
+	await test.step("削除された顧客を検索してもヒットしないことを確認", async () => {
+		await page.getByLabel("検索キーワード").fill(customer.name);
+		await page.getByRole("button", { name: "検索" }).click();
+
+		// 「顧客が見つかりませんでした」が表示される
+		await expect(page.getByText("顧客が見つかりませんでした")).toBeVisible();
+	});
+});
+
+test("一般ユーザーには顧客削除ボタンが表示されない", async ({
+	page,
+	customer,
+}) => {
+	const testUser = {
+		email: "test1@example.com",
+		password: "Test@Pass123",
+	};
+
+	await test.step("一般ユーザーでログイン", async () => {
+		await page.goto("/login");
+		await page.getByLabel("メールアドレス").fill(testUser.email);
+		await page
+			.getByRole("textbox", { name: "パスワード" })
+			.fill(testUser.password);
+		await page.getByRole("button", { name: "ログイン" }).click();
+		await page.waitForURL("/");
+	});
+
+	await test.step("顧客詳細ページに遷移", async () => {
+		await page.goto(`/customers/${customer.customerId}`);
+		await page.waitForURL(`/customers/${customer.customerId}`);
+	});
+
+	await test.step("削除ボタンが表示されないことを確認", async () => {
+		// 編集リンクは表示される
+		await expect(page.getByRole("link", { name: "編集" })).toBeVisible();
+
+		// 削除ボタンは表示されない
+		await expect(page.getByRole("button", { name: "削除" })).toBeHidden();
+	});
+});

--- a/apps/web/e2e/customer-delete.e2e.test.ts
+++ b/apps/web/e2e/customer-delete.e2e.test.ts
@@ -1,17 +1,37 @@
-import { test as base, expect } from "@playwright/test";
+import { test as base, expect, type Page } from "@playwright/test";
 import { db } from "@workspace/db/client";
 import { customersTable } from "@workspace/db/schema/customer";
 import { eq } from "drizzle-orm";
 import { v4 } from "uuid";
 
-const test = base.extend<{
+type Fixtures = {
 	customer: {
 		customerId: string;
 		email: string;
 		name: string;
 		phone: string;
 	};
-}>({
+	adminUserPage: Page;
+	normalUserPage: Page;
+};
+
+const test = base.extend<Fixtures>({
+	async adminUserPage({ page }, use) {
+		const adminUser = {
+			email: "admin@example.com",
+			password: "Admin@789!",
+		};
+
+		await page.goto("/login");
+		await page.getByLabel("メールアドレス").fill(adminUser.email);
+		await page
+			.getByRole("textbox", { name: "パスワード" })
+			.fill(adminUser.password);
+		await page.getByRole("button", { name: "ログイン" }).click();
+		await page.waitForURL("/");
+
+		await use(page);
+	},
 	// biome-ignore lint/correctness/noEmptyPattern: The first argument inside a fixture must use object destructuring pattern, e.g. ({ test } => {}). Instead, received "_".
 	async customer({}, use) {
 		const customer = {
@@ -27,60 +47,42 @@ const test = base.extend<{
 			.delete(customersTable)
 			.where(eq(customersTable.customerId, customer.customerId));
 	},
-});
 
-test("管理者が顧客を削除できる", async ({ page, customer }) => {
-	const adminUser = {
-		email: "admin@example.com",
-		password: "Admin@789!",
-	};
+	async normalUserPage({ page }, use) {
+		const testUser = {
+			email: "test1@example.com",
+			password: "Test@Pass123",
+		};
 
-	await test.step("管理者でログイン", async () => {
 		await page.goto("/login");
-		await page.getByLabel("メールアドレス").fill(adminUser.email);
+		await page.getByLabel("メールアドレス").fill(testUser.email);
 		await page
 			.getByRole("textbox", { name: "パスワード" })
-			.fill(adminUser.password);
+			.fill(testUser.password);
 		await page.getByRole("button", { name: "ログイン" }).click();
 		await page.waitForURL("/");
-	});
 
+		await use(page);
+	},
+});
+
+test("管理者が顧客を削除できる", async ({ adminUserPage: page, customer }) => {
 	await test.step("顧客詳細ページに遷移", async () => {
 		await page.goto(`/customers/${customer.customerId}`);
 		await page.waitForURL(`/customers/${customer.customerId}`);
 	});
 
-	await test.step("顧客詳細ページで削除ボタンをクリック", async () => {
-		// 削除ボタンが表示されることを確認
-		const deleteButton = page.getByRole("button", { name: "削除" });
-		await expect(deleteButton).toBeVisible();
-
-		await deleteButton.click();
-
-		// 削除確認ダイアログが表示されることを確認
-		const dialog = page.getByRole("dialog");
-		await expect(
-			dialog.getByRole("heading", { name: "顧客を削除" }),
-		).toBeVisible();
-		await expect(
-			dialog.getByText(
-				"この顧客を削除してもよろしいですか？関連するすべてのノートと画像も削除されます。この操作は取り消せません。",
-			),
-		).toBeVisible();
-	});
-
-	await test.step("確認ダイアログで削除を実行", async () => {
-		const dialog = page.getByRole("dialog");
-		await dialog.getByRole("button", { name: "削除" }).click();
-
-		// ダイアログが閉じることを確認
-		await expect(dialog).toBeHidden();
-
-		// 顧客一覧ページにリダイレクトされることを確認
-		await page.waitForURL("/customers");
+	await test.step("削除実行", async () => {
+		await page.getByRole("button", { name: "削除" }).click();
+		await page
+			.getByRole("dialog")
+			.getByRole("button", { name: "削除" })
+			.click();
 	});
 
 	await test.step("削除された顧客を検索してもヒットしないことを確認", async () => {
+		await page.waitForURL("/customers");
+
 		await page.getByLabel("検索キーワード").fill(customer.name);
 		await page.getByRole("button", { name: "検索" }).click();
 
@@ -90,34 +92,16 @@ test("管理者が顧客を削除できる", async ({ page, customer }) => {
 });
 
 test("一般ユーザーには顧客削除ボタンが表示されない", async ({
-	page,
+	normalUserPage: page,
 	customer,
 }) => {
-	const testUser = {
-		email: "test1@example.com",
-		password: "Test@Pass123",
-	};
-
-	await test.step("一般ユーザーでログイン", async () => {
-		await page.goto("/login");
-		await page.getByLabel("メールアドレス").fill(testUser.email);
-		await page
-			.getByRole("textbox", { name: "パスワード" })
-			.fill(testUser.password);
-		await page.getByRole("button", { name: "ログイン" }).click();
-		await page.waitForURL("/");
-	});
-
 	await test.step("顧客詳細ページに遷移", async () => {
 		await page.goto(`/customers/${customer.customerId}`);
 		await page.waitForURL(`/customers/${customer.customerId}`);
 	});
 
 	await test.step("削除ボタンが表示されないことを確認", async () => {
-		// 編集リンクは表示される
 		await expect(page.getByRole("link", { name: "編集" })).toBeVisible();
-
-		// 削除ボタンは表示されない
 		await expect(page.getByRole("button", { name: "削除" })).toBeHidden();
 	});
 });

--- a/apps/web/features/customer/delete/delete-customer-action.small.server.test.ts
+++ b/apps/web/features/customer/delete/delete-customer-action.small.server.test.ts
@@ -1,0 +1,95 @@
+import { test as base, expect, type Mock, vi } from "vitest";
+import { deleteCustomerAction } from "./delete-customer-action";
+
+// 依存関係をモック
+vi.mock("@repo/logger/nextjs/server", () => ({
+	getLogger: vi.fn().mockResolvedValue({
+		info: vi.fn(),
+		warn: vi.fn(),
+	}),
+}));
+
+vi.mock("@/features/auth/get-user-staff-id", () => ({
+	getUserStaffId: vi.fn(),
+}));
+
+vi.mock("@/features/auth/get-user-role", () => ({
+	getUserRole: vi.fn(),
+}));
+
+const test = base.extend<{
+	getUserStaffIdMock: Mock;
+	getUserRoleMock: Mock;
+}>({
+	// biome-ignore lint/correctness/noEmptyPattern: Vitestのfixtureパターンで使用する標準的な記法
+	// biome-ignore lint/suspicious/noExplicitAny: https://github.com/vitest-dev/vitest/discussions/5710
+	getUserRoleMock: async ({}, use: any) => {
+		const getUserRoleModule = await import("@/features/auth/get-user-role");
+		const mock = vi.mocked(getUserRoleModule.getUserRole);
+		await use(mock);
+		vi.clearAllMocks();
+	},
+	// biome-ignore lint/correctness/noEmptyPattern: Vitestのfixtureパターンで使用する標準的な記法
+	// biome-ignore lint/suspicious/noExplicitAny: https://github.com/vitest-dev/vitest/discussions/5710
+	getUserStaffIdMock: async ({}, use: any) => {
+		const getUserStaffIdModule = await import(
+			"@/features/auth/get-user-staff-id"
+		);
+		const mock = vi.mocked(getUserStaffIdModule.getUserStaffId);
+		await use(mock);
+		vi.clearAllMocks();
+	},
+});
+
+test("一般ユーザーロールの場合、権限エラーが返される", async ({
+	getUserStaffIdMock,
+	getUserRoleMock,
+}) => {
+	const testCustomerId = "00000000-0000-0000-0000-000000000001";
+
+	getUserStaffIdMock.mockResolvedValue("staff-id");
+	getUserRoleMock.mockResolvedValue("user");
+
+	const result = await deleteCustomerAction({
+		customerId: testCustomerId,
+	});
+
+	expect(result.success).toBe(false);
+	if (!result.success) {
+		expect(result.error).toBe("この操作を実行する権限がありません");
+	}
+});
+
+test("認証されていない場合、認証エラーが返される", async ({
+	getUserStaffIdMock,
+}) => {
+	const testCustomerId = "00000000-0000-0000-0000-000000000001";
+
+	getUserStaffIdMock.mockResolvedValue(null);
+
+	const result = await deleteCustomerAction({
+		customerId: testCustomerId,
+	});
+
+	expect(result.success).toBe(false);
+	if (!result.success) {
+		expect(result.error).toBe("認証に失敗しました");
+	}
+});
+
+test("不正なcustomerIdの場合、バリデーションエラーが返される", async ({
+	getUserStaffIdMock,
+	getUserRoleMock,
+}) => {
+	getUserStaffIdMock.mockResolvedValue("staff-id");
+	getUserRoleMock.mockResolvedValue("admin");
+
+	const result = await deleteCustomerAction({
+		customerId: "invalid-uuid",
+	});
+
+	expect(result.success).toBe(false);
+	if (!result.success) {
+		expect(result.error).toBe("入力内容に誤りがあります");
+	}
+});

--- a/apps/web/features/customer/delete/delete-customer-action.ts
+++ b/apps/web/features/customer/delete/delete-customer-action.ts
@@ -1,0 +1,86 @@
+"use server";
+
+import { fail, type Result, succeed } from "@harusame0616/result";
+import { EventType } from "@repo/logger/event-types";
+import { getLogger } from "@repo/logger/nextjs/server";
+import { updateTag } from "next/cache";
+import * as v from "valibot";
+import { getUserRole } from "@/features/auth/get-user-role";
+import { getUserStaffId } from "@/features/auth/get-user-staff-id";
+import { CustomerTag } from "@/features/customer/tag";
+import { deleteCustomer } from "./delete-customer";
+
+const INVALID_INPUT_ERROR_MESSAGE = "入力内容に誤りがあります" as const;
+const UNAUTHORIZED_ERROR_MESSAGE = "認証に失敗しました" as const;
+const FORBIDDEN_ERROR_MESSAGE = "この操作を実行する権限がありません" as const;
+const CUSTOMER_NOT_FOUND_ERROR_MESSAGE =
+	"指定された顧客が見つかりません" as const;
+const INTERNAL_SERVER_ERROR_MESSAGE =
+	"サーバーエラーが発生しました。時間をおいて再度お試しください" as const;
+
+type DeleteCustomerActionErrorMessage =
+	| typeof INVALID_INPUT_ERROR_MESSAGE
+	| typeof UNAUTHORIZED_ERROR_MESSAGE
+	| typeof FORBIDDEN_ERROR_MESSAGE
+	| typeof CUSTOMER_NOT_FOUND_ERROR_MESSAGE
+	| typeof INTERNAL_SERVER_ERROR_MESSAGE;
+
+const deleteCustomerSchema = v.object({
+	customerId: v.pipe(v.string(), v.uuid()),
+});
+
+type DeleteCustomerInput = v.InferInput<typeof deleteCustomerSchema>;
+
+export async function deleteCustomerAction(
+	params: DeleteCustomerInput,
+): Promise<Result<undefined, DeleteCustomerActionErrorMessage>> {
+	const logger = await getLogger("deleteCustomerAction");
+	logger.info("deleteCustomerAction を実行", {
+		params,
+	});
+
+	// バリデーション
+	const paramsParseResult = v.safeParse(deleteCustomerSchema, params);
+	if (!paramsParseResult.success) {
+		logger.warn("バリデーション失敗", {
+			event: EventType.InputValidationError,
+			issues: paramsParseResult.issues,
+		});
+		return fail(INVALID_INPUT_ERROR_MESSAGE);
+	}
+
+	const { customerId } = paramsParseResult.output;
+
+	// 認証情報の取得
+	const userId = await getUserStaffId();
+	if (!userId) {
+		logger.warn("認証されていないアクセス", {
+			event: EventType.AuthenticationFailure,
+		});
+		return fail(UNAUTHORIZED_ERROR_MESSAGE);
+	}
+
+	const role = await getUserRole();
+	if (role !== "admin") {
+		logger.warn("権限がないアクセス", {
+			customerId,
+			event: EventType.AuthorizationError,
+		});
+		return fail(FORBIDDEN_ERROR_MESSAGE);
+	}
+
+	// 削除処理を実行
+	const result = await deleteCustomer({
+		customerId,
+	});
+
+	if (!result.success) {
+		return result;
+	}
+
+	// キャッシュの更新
+	updateTag(CustomerTag.crud);
+	updateTag(CustomerTag.NoteCrud(customerId));
+
+	return succeed();
+}

--- a/apps/web/features/customer/delete/delete-customer-dialog.browser.test.tsx
+++ b/apps/web/features/customer/delete/delete-customer-dialog.browser.test.tsx
@@ -1,0 +1,46 @@
+import { expect, test, vi } from "vitest";
+import { page } from "vitest/browser";
+import { render } from "vitest-browser-react";
+import { DeleteCustomerDialog } from "./delete-customer-dialog";
+
+// Server Actionをモック
+vi.mock("./delete-customer-action", () => ({
+	deleteCustomerAction: vi.fn(),
+}));
+
+test("削除ボタンをクリックするとダイアログが表示される", async () => {
+	render(<DeleteCustomerDialog customerId="test-id" />);
+
+	// 削除ボタンをクリック
+	await page.getByRole("button", { name: "削除" }).click();
+
+	// ダイアログが表示される
+	const dialog = page.getByRole("dialog");
+	await expect.element(dialog).toBeInTheDocument();
+	await expect
+		.element(dialog.getByRole("heading", { name: "顧客を削除" }))
+		.toBeInTheDocument();
+	await expect
+		.element(
+			dialog.getByText(
+				"この顧客を削除してもよろしいですか？関連するすべてのノートと画像も削除されます。この操作は取り消せません。",
+			),
+		)
+		.toBeInTheDocument();
+});
+
+test("キャンセルボタンをクリックするとダイアログが閉じる", async () => {
+	render(<DeleteCustomerDialog customerId="test-id" />);
+
+	// 削除ボタンをクリックしてダイアログを開く
+	await page.getByRole("button", { name: "削除" }).click();
+
+	const dialog = page.getByRole("dialog");
+	await expect.element(dialog).toBeInTheDocument();
+
+	// キャンセルボタンをクリック
+	await dialog.getByRole("button", { name: "キャンセル" }).click();
+
+	// ダイアログが閉じる
+	await expect.element(dialog).not.toBeInTheDocument();
+});

--- a/apps/web/features/customer/delete/delete-customer.medium.server.test.ts
+++ b/apps/web/features/customer/delete/delete-customer.medium.server.test.ts
@@ -1,0 +1,70 @@
+import { db } from "@workspace/db/client";
+import { customersTable } from "@workspace/db/schema/customer";
+import { eq } from "drizzle-orm";
+import { v4 } from "uuid";
+import { test as base, expect, vi } from "vitest";
+import { deleteCustomer } from "./delete-customer";
+
+// Loggerをモック
+vi.mock("@repo/logger/nextjs/server", () => ({
+	getLogger: vi.fn().mockResolvedValue({
+		error: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+	}),
+}));
+
+const test = base.extend<{
+	customer: {
+		customerId: string;
+		email: string;
+		name: string;
+		phone: string;
+	};
+}>({
+	// biome-ignore lint/correctness/noEmptyPattern: The first argument inside a fixture must use object destructuring pattern, e.g. ({ test } => {}). Instead, received "_".
+	async customer({}, use) {
+		const customer = {
+			customerId: v4(),
+			email: `${v4()}@example.com`,
+			name: v4().slice(0, 24),
+			phone: `${Math.floor(Math.random() * 1000000000)}`,
+		};
+
+		await db.insert(customersTable).values(customer);
+		await use(customer);
+		await db
+			.delete(customersTable)
+			.where(eq(customersTable.customerId, customer.customerId));
+	},
+});
+
+test("存在しない顧客を削除しようとした場合にエラーが返される", async () => {
+	const nonExistentCustomerId = "99999999-9999-9999-9999-999999999999";
+
+	const result = await deleteCustomer({
+		customerId: nonExistentCustomerId,
+	});
+
+	expect(result.success).toBe(false);
+	if (!result.success) {
+		expect(result.error).toBe("指定された顧客が見つかりません");
+	}
+});
+
+test("存在する顧客を削除できる", async ({ customer }) => {
+	const result = await deleteCustomer({
+		customerId: customer.customerId,
+	});
+
+	expect(result.success).toBe(true);
+
+	// 削除されたことを確認
+	const [deletedCustomer] = await db
+		.select()
+		.from(customersTable)
+		.where(eq(customersTable.customerId, customer.customerId))
+		.limit(1);
+
+	expect(deletedCustomer).toBeUndefined();
+});

--- a/apps/web/features/customer/delete/delete-customer.ts
+++ b/apps/web/features/customer/delete/delete-customer.ts
@@ -1,0 +1,107 @@
+import { fail, type Result, succeed } from "@harusame0616/result";
+import { getLogger } from "@repo/logger/nextjs/server";
+import { createAdminClient } from "@repo/supabase/admin";
+import { db } from "@workspace/db/client";
+import { customersTable } from "@workspace/db/schema/customer";
+import {
+	customerNoteImagesTable,
+	customerNotesTable,
+} from "@workspace/db/schema/customer-note";
+import { eq } from "drizzle-orm";
+
+const CUSTOMER_NOT_FOUND_ERROR_MESSAGE =
+	"指定された顧客が見つかりません" as const;
+const INTERNAL_SERVER_ERROR_MESSAGE =
+	"サーバーエラーが発生しました。時間をおいて再度お試しください" as const;
+
+type DeleteCustomerErrorMessage =
+	| typeof CUSTOMER_NOT_FOUND_ERROR_MESSAGE
+	| typeof INTERNAL_SERVER_ERROR_MESSAGE;
+
+const BUCKET_NAME = "customer-note-attachments";
+
+type DeleteCustomerInput = {
+	customerId: string;
+};
+
+export async function deleteCustomer({
+	customerId,
+}: DeleteCustomerInput): Promise<
+	Result<undefined, DeleteCustomerErrorMessage>
+> {
+	const logger = await getLogger("deleteCustomer");
+
+	try {
+		// 顧客の存在確認
+		const [customer] = await db
+			.select()
+			.from(customersTable)
+			.where(eq(customersTable.customerId, customerId))
+			.limit(1);
+
+		if (!customer) {
+			logger.warn("顧客が見つかりません", {
+				customerId,
+			});
+			return fail(CUSTOMER_NOT_FOUND_ERROR_MESSAGE);
+		}
+
+		// 顧客に関連するノートの画像を取得
+		const images = await db
+			.select({
+				path: customerNoteImagesTable.path,
+			})
+			.from(customerNoteImagesTable)
+			.innerJoin(
+				customerNotesTable,
+				eq(customerNoteImagesTable.customerNoteId, customerNotesTable.id),
+			)
+			.where(eq(customerNotesTable.customerId, customerId));
+
+		// 顧客を削除（関連ノートと画像はカスケード削除される）
+		await db
+			.delete(customersTable)
+			.where(eq(customersTable.customerId, customerId));
+
+		// 画像がない場合は早期リターン
+		if (images.length === 0) {
+			logger.info("顧客の削除に成功", {
+				action: "delete-customer",
+				customerId,
+				imageCount: 0,
+			});
+			return succeed();
+		}
+
+		// Supabase Storage から画像ファイルを削除（並列処理）
+		const supabase = createAdminClient();
+		await Promise.allSettled(
+			images.map(async (image) => {
+				const { error } = await supabase.storage
+					.from(BUCKET_NAME)
+					.remove([image.path]);
+
+				if (error) {
+					logger.error("画像ファイルの削除に失敗", {
+						err: error,
+						path: image.path,
+					});
+				}
+			}),
+		);
+
+		logger.info("顧客の削除に成功", {
+			action: "delete-customer",
+			customerId,
+			imageCount: images.length,
+		});
+
+		return succeed();
+	} catch (error) {
+		logger.error("顧客の削除に失敗", {
+			action: "delete-customer",
+			err: error,
+		});
+		return fail(INTERNAL_SERVER_ERROR_MESSAGE);
+	}
+}


### PR DESCRIPTION
## 概要

管理者ロールのユーザーが顧客を削除できる機能を実装しました。

## 実装内容

### ビジネスロジック層
- `deleteCustomer` 関数で顧客削除処理を実装
- 顧客IDを受け取り、データベースから顧客を削除

### Server Action層
- 認証・認可チェック（管理者ロールのみ許可）
- 入力バリデーション（UUID形式の検証）
- ロギング（削除イベント、エラーイベントの記録）

### UI層
- 削除確認ダイアログコンポーネント
- 誤操作防止のための確認メッセージ表示
- 削除後は顧客一覧ページへリダイレクト

## テスト

### E2Eテスト（`customer-delete.e2e.test.ts`）
- 管理者による削除フローの検証
- 削除後の検索結果確認
- 一般ユーザーには削除ボタンが表示されないことの確認

### ブラウザテスト（`delete-customer-dialog.browser.test.tsx`）
- ダイアログの開閉動作
- キャンセルボタンの動作確認

### Server小テスト（`delete-customer-action.small.server.test.ts`）
- Server Actionの認証チェック
- 認可チェック（管理者ロール）
- 入力バリデーション

### Server中テスト（`delete-customer.medium.server.test.ts`）
- ビジネスロジックの統合テスト
- 存在する顧客の削除成功
- 存在しない顧客の削除時のエラー処理

## 特徴

- **役割に基づくアクセス制御**: 管理者ロールのユーザーのみが削除可能
- **誤操作防止**: 削除確認ダイアログによる二段階確認
- **テスト分離**: Fixture パターンによる各テストの独立性確保
- **適切なレイヤー分離**: 認証・認可はServer Action、データ操作はビジネスロジック

## 変更ファイル

- `apps/web/app/(private)/customers/[customerId]/@action/page.tsx` - 削除ダイアログの配置
- `apps/web/features/customer/delete/delete-customer.ts` - ビジネスロジック
- `apps/web/features/customer/delete/delete-customer-action.ts` - Server Action
- `apps/web/features/customer/delete/delete-customer-dialog.tsx` - UIコンポーネント
- `apps/web/e2e/customer-delete.e2e.test.ts` - E2Eテスト
- `apps/web/features/customer/delete/delete-customer-dialog.browser.test.tsx` - ブラウザテスト
- `apps/web/features/customer/delete/delete-customer-action.small.server.test.ts` - Server小テスト
- `apps/web/features/customer/delete/delete-customer.medium.server.test.ts` - Server中テスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)