### PR TITLE
feat: createServerAction ヘルパー関数を追加し全 Server Action を置き換え

### DIFF
--- a/apps/web/features/auth/login/login-action.small.server.test.ts
+++ b/apps/web/features/auth/login/login-action.small.server.test.ts
@@ -1,5 +1,21 @@
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import { loginAction } from "./login-action";
+
+vi.mock("@repo/logger/nextjs/server", () => ({
+	getLogger: vi.fn().mockResolvedValue({
+		error: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+	}),
+}));
+
+vi.mock("@/features/auth/get-user-staff-id", () => ({
+	getUserStaffId: vi.fn(),
+}));
+
+vi.mock("@/features/auth/get-user-role", () => ({
+	getUserRole: vi.fn(),
+}));
 
 test.each([
 	{ description: "引数が undefined", input: undefined },

--- a/apps/web/features/auth/login/login-action.ts
+++ b/apps/web/features/auth/login/login-action.ts
@@ -1,31 +1,15 @@
 "use server";
 
-import { fail, type Result } from "@harusame0616/result";
 import { RedirectType, redirect } from "next/navigation";
-import * as v from "valibot";
-import { type LoginErrorMessage, login } from "@/features/auth/login/login";
-import { type LoginSchema, loginSchema } from "@/features/auth/schema";
+import { login } from "@/features/auth/login/login";
+import { loginSchema } from "@/features/auth/schema";
+import { createServerAction } from "@/libs/create-server-action";
 
-const INVALID_INPUT_ERROR_MESSAGE = "入力内容に誤りがあります" as const;
-
-type LoginActionErrorMessage =
-	| LoginErrorMessage
-	| typeof INVALID_INPUT_ERROR_MESSAGE;
-
-export async function loginAction(
-	params: LoginSchema,
-): Promise<Result<never, LoginActionErrorMessage>> {
-	const paramsParseResult = v.safeParse(loginSchema, params);
-	if (!paramsParseResult.success) {
-		return fail(INVALID_INPUT_ERROR_MESSAGE);
-	}
-
-	// ログイン処理
-	const loginResult = await login(paramsParseResult.output);
-
-	if (!loginResult.success) {
-		return fail(loginResult.error);
-	}
-
-	redirect("/", RedirectType.replace);
-}
+export const loginAction = createServerAction(login, {
+	isPublic: true,
+	name: "loginAction",
+	onSuccess: () => {
+		redirect("/", RedirectType.replace);
+	},
+	schema: loginSchema,
+});

--- a/apps/web/features/auth/login/login.ts
+++ b/apps/web/features/auth/login/login.ts
@@ -8,11 +8,9 @@ type LoginParams = v.InferOutput<typeof loginSchema>;
 const LoginErrorMessage =
 	"ログインできませんでした。メールアドレス・パスワードを確認し、解決しない場合は時間をおくか管理者にお問い合わせください。" as const;
 
-export type LoginErrorMessage = typeof LoginErrorMessage;
-
 export async function login(
 	params: LoginParams,
-): Promise<Result<void, LoginErrorMessage>> {
+): Promise<Result<void, typeof LoginErrorMessage>> {
 	const supabase = await createClient();
 
 	const { error } = await supabase.auth.signInWithPassword({

--- a/apps/web/features/customer-note/delete/delete-customer-note-action.ts
+++ b/apps/web/features/customer-note/delete/delete-customer-note-action.ts
@@ -1,79 +1,36 @@
 "use server";
 
-import { fail, type Result, succeed } from "@harusame0616/result";
-import { EventType } from "@repo/logger/event-types";
-import { getLogger } from "@repo/logger/nextjs/server";
+import { succeed } from "@harusame0616/result";
 import { updateTag } from "next/cache";
 import * as v from "valibot";
-import { getUserRole } from "@/features/auth/get-user-role";
-import { getUserStaffId } from "@/features/auth/get-user-staff-id";
 import { CustomerTag } from "@/features/customer/tag";
+import { createServerAction } from "@/libs/create-server-action";
 import { deleteCustomerNote } from "./delete-customer-note";
-
-const INVALID_INPUT_ERROR_MESSAGE = "入力内容に誤りがあります" as const;
-const UNAUTHORIZED_ERROR_MESSAGE = "認証に失敗しました" as const;
-const FORBIDDEN_ERROR_MESSAGE = "この操作を実行する権限がありません" as const;
-const NOTE_NOT_FOUND_ERROR_MESSAGE =
-	"指定されたノートが見つかりません" as const;
-const INTERNAL_SERVER_ERROR_MESSAGE =
-	"サーバーエラーが発生しました。時間をおいて再度お試しください" as const;
-
-type DeleteCustomerNoteActionErrorMessage =
-	| typeof INVALID_INPUT_ERROR_MESSAGE
-	| typeof UNAUTHORIZED_ERROR_MESSAGE
-	| typeof FORBIDDEN_ERROR_MESSAGE
-	| typeof NOTE_NOT_FOUND_ERROR_MESSAGE
-	| typeof INTERNAL_SERVER_ERROR_MESSAGE;
 
 const deleteCustomerNoteSchema = v.object({
 	noteId: v.pipe(v.string(), v.uuid()),
 });
 
-type DeleteCustomerNoteInput = v.InferInput<typeof deleteCustomerNoteSchema>;
-
-export async function deleteCustomerNoteAction(
-	params: DeleteCustomerNoteInput,
-): Promise<Result<undefined, DeleteCustomerNoteActionErrorMessage>> {
-	const logger = await getLogger("deleteCustomerNoteAction");
-	logger.info("deleteCustomerNoteAction を実行", {
-		params,
-	});
-
-	// バリデーション
-	const paramsParseResult = v.safeParse(deleteCustomerNoteSchema, params);
-	if (!paramsParseResult.success) {
-		logger.warn("バリデーション失敗", {
-			event: EventType.InputValidationError,
-			issues: paramsParseResult.issues,
+export const deleteCustomerNoteAction = createServerAction(
+	async (input, { role, userId }) => {
+		// biome-ignore lint/style/noNonNullAssertion: isPublic: false のため認証済みで非null
+		const user = { role: role!, userId: userId! };
+		const result = await deleteCustomerNote({
+			customerNoteId: input.noteId,
+			user,
 		});
-		return fail(INVALID_INPUT_ERROR_MESSAGE);
-	}
 
-	const { noteId } = paramsParseResult.output;
+		if (!result.success) {
+			return result;
+		}
 
-	// 認証情報の取得
-	const userId = await getUserStaffId();
-	if (!userId) {
-		logger.warn("認証されていないアクセス", {
-			event: EventType.AuthenticationFailure,
-		});
-		return fail(UNAUTHORIZED_ERROR_MESSAGE);
-	}
-
-	const role = await getUserRole();
-
-	// 削除処理を実行
-	const result = await deleteCustomerNote({
-		customerNoteId: noteId,
-		user: { role, userId },
-	});
-
-	if (!result.success) {
-		return result;
-	}
-
-	// キャッシュの更新
-	updateTag(CustomerTag.NoteCrud(result.data.customerId));
-
-	return succeed();
-}
+		return succeed({ customerId: result.data.customerId });
+	},
+	{
+		name: "deleteCustomerNoteAction",
+		onSuccess: ({ result }) => {
+			updateTag(CustomerTag.NoteCrud(result.customerId));
+		},
+		schema: deleteCustomerNoteSchema,
+	},
+);

--- a/apps/web/features/customer-note/edit/edit-customer-note-action.ts
+++ b/apps/web/features/customer-note/edit/edit-customer-note-action.ts
@@ -1,29 +1,11 @@
 "use server";
 
-import { fail, type Result, succeed } from "@harusame0616/result";
-import { EventType } from "@repo/logger/event-types";
-import { getLogger } from "@repo/logger/nextjs/server";
+import { succeed } from "@harusame0616/result";
 import { updateTag } from "next/cache";
 import * as v from "valibot";
-import { getUserRole } from "@/features/auth/get-user-role";
-import { getUserStaffId } from "@/features/auth/get-user-staff-id";
 import { CustomerTag } from "@/features/customer/tag";
+import { createServerAction } from "@/libs/create-server-action";
 import { editCustomerNote } from "./edit-customer-note";
-
-const INVALID_INPUT_ERROR_MESSAGE = "入力内容に誤りがあります" as const;
-const UNAUTHORIZED_ERROR_MESSAGE = "認証に失敗しました" as const;
-const FORBIDDEN_ERROR_MESSAGE = "この操作を実行する権限がありません" as const;
-const NOTE_NOT_FOUND_ERROR_MESSAGE =
-	"指定されたノートが見つかりません" as const;
-const INTERNAL_SERVER_ERROR_MESSAGE =
-	"サーバーエラーが発生しました。時間をおいて再度お試しください" as const;
-
-type EditCustomerNoteActionErrorMessage =
-	| typeof INVALID_INPUT_ERROR_MESSAGE
-	| typeof UNAUTHORIZED_ERROR_MESSAGE
-	| typeof FORBIDDEN_ERROR_MESSAGE
-	| typeof NOTE_NOT_FOUND_ERROR_MESSAGE
-	| typeof INTERNAL_SERVER_ERROR_MESSAGE;
 
 const uploadImageSchema = v.object({
 	permanentPath: v.string(),
@@ -41,55 +23,31 @@ const editCustomerNoteSchema = v.object({
 	uploadImages: v.optional(v.array(uploadImageSchema), []),
 });
 
-type EditCustomerNoteInput = v.InferInput<typeof editCustomerNoteSchema>;
+export const editCustomerNoteAction = createServerAction(
+	async (input, { role, userId }) => {
+		const { content, keepImagePaths, noteId, uploadImages } = input;
 
-export async function editCustomerNoteAction(
-	params: EditCustomerNoteInput,
-): Promise<Result<undefined, EditCustomerNoteActionErrorMessage>> {
-	const logger = await getLogger("editCustomerNoteAction");
-	logger.info("editCustomerNoteAction を実行", {
-		params,
-	});
-
-	// バリデーション
-	const paramsParseResult = v.safeParse(editCustomerNoteSchema, params);
-	if (!paramsParseResult.success) {
-		logger.warn("バリデーション失敗", {
-			event: EventType.InputValidationError,
-			issues: paramsParseResult.issues,
+		// biome-ignore lint/style/noNonNullAssertion: isPublic: false のため認証済みで非null
+		const user = { role: role!, userId: userId! };
+		const result = await editCustomerNote({
+			content,
+			customerNoteId: noteId,
+			keepImagePaths,
+			uploadImages,
+			user,
 		});
-		return fail(INVALID_INPUT_ERROR_MESSAGE);
-	}
 
-	const { content, noteId, uploadImages, keepImagePaths } =
-		paramsParseResult.output;
+		if (!result.success) {
+			return result;
+		}
 
-	// 認証情報の取得
-	const userId = await getUserStaffId();
-	if (!userId) {
-		logger.warn("認証されていないアクセス", {
-			event: EventType.AuthenticationFailure,
-		});
-		return fail(UNAUTHORIZED_ERROR_MESSAGE);
-	}
-
-	const role = await getUserRole();
-
-	// 編集処理を実行
-	const result = await editCustomerNote({
-		content,
-		customerNoteId: noteId,
-		keepImagePaths,
-		uploadImages,
-		user: { role, userId },
-	});
-
-	if (!result.success) {
-		return result;
-	}
-
-	// キャッシュの更新
-	updateTag(CustomerTag.NoteCrud(result.data.customerId));
-
-	return succeed();
-}
+		return succeed({ customerId: result.data.customerId });
+	},
+	{
+		name: "editCustomerNoteAction",
+		onSuccess: ({ result }) => {
+			updateTag(CustomerTag.NoteCrud(result.customerId));
+		},
+		schema: editCustomerNoteSchema,
+	},
+);

--- a/apps/web/features/customer-note/register/create-upload-url-action.ts
+++ b/apps/web/features/customer-note/register/create-upload-url-action.ts
@@ -1,21 +1,9 @@
 "use server";
 
-import { fail, type Result, succeed } from "@harusame0616/result";
-import { EventType } from "@repo/logger/event-types";
-import { getLogger } from "@repo/logger/nextjs/server";
+import { fail, succeed } from "@harusame0616/result";
 import { createAdminClient } from "@repo/supabase/admin";
 import * as v from "valibot";
-import { getUserStaffId } from "@/features/auth/get-user-staff-id";
-
-const UNAUTHORIZED_ERROR_MESSAGE = "認証に失敗しました" as const;
-const INVALID_INPUT_ERROR_MESSAGE = "入力内容に誤りがあります" as const;
-const INTERNAL_SERVER_ERROR_MESSAGE =
-	"サーバーエラーが発生しました。時間をおいて再度お試しください" as const;
-
-type CreateUploadUrlActionErrorMessage =
-	| typeof UNAUTHORIZED_ERROR_MESSAGE
-	| typeof INVALID_INPUT_ERROR_MESSAGE
-	| typeof INTERNAL_SERVER_ERROR_MESSAGE;
+import { createServerAction } from "@/libs/create-server-action";
 
 const BUCKET_NAME = "customer-note-attachments";
 
@@ -23,42 +11,13 @@ const createUploadUrlSchema = v.object({
 	fileId: v.pipe(v.string(), v.uuid()),
 });
 
-type CreateUploadUrlInput = v.InferInput<typeof createUploadUrlSchema>;
+const UPLOAD_URL_CREATE_ERROR_MESSAGE =
+	"署名付きアップロードURLの作成に失敗しました" as const;
 
-type CreateUploadUrlResult = {
-	path: string;
-	token: string;
-	signedUrl: string;
-};
-
-export async function createUploadUrlAction(
-	params: CreateUploadUrlInput,
-): Promise<Result<CreateUploadUrlResult, CreateUploadUrlActionErrorMessage>> {
-	const logger = await getLogger("createUploadUrlAction");
-	logger.info("アップロードURLの作成を実行");
-
-	const paramsParseResult = v.safeParse(createUploadUrlSchema, params);
-	if (!paramsParseResult.success) {
-		logger.warn("バリデーションに失敗しました", {
-			event: EventType.InputValidationError,
-			issues: paramsParseResult.issues,
-		});
-		return fail(INVALID_INPUT_ERROR_MESSAGE);
-	}
-
-	const { fileId } = paramsParseResult.output;
-
-	const staffId = await getUserStaffId();
-	if (!staffId) {
-		logger.warn("未認証のアクセス", {
-			event: EventType.AuthenticationFailure,
-		});
-		return fail(UNAUTHORIZED_ERROR_MESSAGE);
-	}
-
-	try {
+export const createUploadUrlAction = createServerAction(
+	async (input, { logger, userId }) => {
 		const supabase = createAdminClient();
-		const path = `temporary/${fileId}`;
+		const path = `temporary/${input.fileId}`;
 
 		const { data, error } = await supabase.storage
 			.from(BUCKET_NAME)
@@ -69,12 +28,12 @@ export async function createUploadUrlAction(
 				err: error,
 				path,
 			});
-			return fail(INTERNAL_SERVER_ERROR_MESSAGE);
+			return fail(UPLOAD_URL_CREATE_ERROR_MESSAGE);
 		}
 
 		logger.info("署名付きアップロードURLの作成に成功しました", {
 			path,
-			staffId,
+			staffId: userId,
 		});
 
 		return succeed({
@@ -82,10 +41,9 @@ export async function createUploadUrlAction(
 			signedUrl: data.signedUrl,
 			token: data.token,
 		});
-	} catch (error) {
-		logger.error("予期しないエラーが発生しました", {
-			err: error,
-		});
-		return fail(INTERNAL_SERVER_ERROR_MESSAGE);
-	}
-}
+	},
+	{
+		name: "createUploadUrlAction",
+		schema: createUploadUrlSchema,
+	},
+);

--- a/apps/web/features/customer-note/register/register-customer-note-action.ts
+++ b/apps/web/features/customer-note/register/register-customer-note-action.ts
@@ -1,9 +1,7 @@
 "use server";
 
 import { randomUUID } from "node:crypto";
-import { fail, type Result, succeed } from "@harusame0616/result";
-import { EventType } from "@repo/logger/event-types";
-import { getLogger } from "@repo/logger/nextjs/server";
+import { succeed } from "@harusame0616/result";
 import { createAdminClient } from "@repo/supabase/admin";
 import { db } from "@workspace/db/client";
 import {
@@ -12,18 +10,8 @@ import {
 } from "@workspace/db/schema/customer-note";
 import { updateTag } from "next/cache";
 import * as v from "valibot";
-import { getUserStaffId } from "@/features/auth/get-user-staff-id";
 import { CustomerTag } from "@/features/customer/tag";
-
-const INVALID_INPUT_ERROR_MESSAGE = "入力内容に誤りがあります" as const;
-const UNAUTHORIZED_ERROR_MESSAGE = "認証に失敗しました" as const;
-const INTERNAL_SERVER_ERROR_MESSAGE =
-	"サーバーエラーが発生しました。時間をおいて再度お試しください" as const;
-
-type RegisterCustomerNoteActionErrorMessage =
-	| typeof INVALID_INPUT_ERROR_MESSAGE
-	| typeof UNAUTHORIZED_ERROR_MESSAGE
-	| typeof INTERNAL_SERVER_ERROR_MESSAGE;
+import { createServerAction } from "@/libs/create-server-action";
 
 const BUCKET_NAME = "customer-note-attachments";
 
@@ -42,45 +30,16 @@ const registerCustomerNoteSchema = v.object({
 	uploadImages: v.optional(v.array(uploadImageSchema), []),
 });
 
-type RegisterCustomerNoteInput = v.InferInput<
-	typeof registerCustomerNoteSchema
->;
+export const registerCustomerNoteAction = createServerAction(
+	async (input, { logger, userId }) => {
+		const { content, customerId, uploadImages } = input;
+		// biome-ignore lint/style/noNonNullAssertion: isPublic: false のため認証済みで非null
+		const staffId = userId!;
 
-export async function registerCustomerNoteAction(
-	params: RegisterCustomerNoteInput,
-): Promise<Result<undefined, RegisterCustomerNoteActionErrorMessage>> {
-	const logger = await getLogger("registerCustomerNoteAction");
-	logger.info("execute registerCustomerNoteAction", {
-		params,
-	});
-
-	// バリデーション
-	const paramsParseResult = v.safeParse(registerCustomerNoteSchema, params);
-	if (!paramsParseResult.success) {
-		logger.warn("Validation failed", {
-			event: EventType.InputValidationError,
-			issues: paramsParseResult.issues,
-		});
-		return fail(INVALID_INPUT_ERROR_MESSAGE);
-	}
-
-	const { content, customerId, uploadImages } = paramsParseResult.output;
-
-	// 認証情報の取得
-	const staffId = await getUserStaffId();
-	if (!staffId) {
-		logger.warn("Unauthorized access", {
-			event: EventType.AuthenticationFailure,
-		});
-		return fail(UNAUTHORIZED_ERROR_MESSAGE);
-	}
-
-	try {
 		const noteId = randomUUID();
 		const supabase = createAdminClient();
 
 		await db.transaction(async (tx) => {
-			// 顧客ノートの登録
 			await tx.insert(customerNotesTable).values({
 				content,
 				customerId,
@@ -88,9 +47,7 @@ export async function registerCustomerNoteAction(
 				staffId,
 			});
 
-			// 画像がある場合は並列で移動してまとめてDB保存
 			if (uploadImages.length > 0) {
-				// 全ての画像を並列で移動
 				const moveResults = await Promise.all(
 					uploadImages.map(async (uploadImage, i) => {
 						const { permanentPath, temporaryPath } = uploadImage;
@@ -118,7 +75,6 @@ export async function registerCustomerNoteAction(
 					}),
 				);
 
-				// 全ての画像情報をまとめてDB保存
 				await tx.insert(customerNoteImagesTable).values(
 					moveResults.map((result) => ({
 						customerNoteId: noteId,
@@ -129,21 +85,13 @@ export async function registerCustomerNoteAction(
 			}
 		});
 
-		logger.info("Customer note registered successfully", {
-			action: "register-customer-note",
-			customerId,
-			imageCount: uploadImages.length,
-			noteId,
-		});
-
-		updateTag(CustomerTag.NoteCrud(customerId));
-	} catch (error) {
-		logger.error("Failed to register customer note", {
-			action: "register-customer-note",
-			err: error,
-		});
-		return fail(INTERNAL_SERVER_ERROR_MESSAGE);
-	}
-
-	return succeed();
-}
+		return succeed();
+	},
+	{
+		name: "registerCustomerNoteAction",
+		onSuccess: ({ input }) => {
+			updateTag(CustomerTag.NoteCrud(input.customerId));
+		},
+		schema: registerCustomerNoteSchema,
+	},
+);

--- a/apps/web/features/customer/delete/delete-customer-action.small.server.test.ts
+++ b/apps/web/features/customer/delete/delete-customer-action.small.server.test.ts
@@ -13,9 +13,14 @@ vi.mock("@/features/auth/get-user-staff-id", () => ({
 	getUserStaffId: vi.fn(),
 }));
 
-vi.mock("@/features/auth/get-user-role", () => ({
-	getUserRole: vi.fn(),
-}));
+vi.mock("@/features/auth/get-user-role", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("@/features/auth/get-user-role")>();
+	return {
+		...actual,
+		getUserRole: vi.fn(),
+	};
+});
 
 const test = base.extend<{
 	getUserStaffIdMock: Mock;

--- a/apps/web/features/customer/delete/delete-customer-action.ts
+++ b/apps/web/features/customer/delete/delete-customer-action.ts
@@ -1,87 +1,24 @@
 "use server";
 
-import { fail, type Result } from "@harusame0616/result";
-import { EventType } from "@repo/logger/event-types";
-import { getLogger } from "@repo/logger/nextjs/server";
 import { updateTag } from "next/cache";
 import { RedirectType, redirect } from "next/navigation";
 import * as v from "valibot";
-import { getUserRole } from "@/features/auth/get-user-role";
-import { getUserStaffId } from "@/features/auth/get-user-staff-id";
+import { UserRole } from "@/features/auth/get-user-role";
 import { CustomerTag } from "@/features/customer/tag";
+import { createServerAction } from "@/libs/create-server-action";
 import { deleteCustomer } from "./delete-customer";
-
-const INVALID_INPUT_ERROR_MESSAGE = "入力内容に誤りがあります" as const;
-const UNAUTHORIZED_ERROR_MESSAGE = "認証に失敗しました" as const;
-const FORBIDDEN_ERROR_MESSAGE = "この操作を実行する権限がありません" as const;
-const CUSTOMER_NOT_FOUND_ERROR_MESSAGE =
-	"指定された顧客が見つかりません" as const;
-const INTERNAL_SERVER_ERROR_MESSAGE =
-	"サーバーエラーが発生しました。時間をおいて再度お試しください" as const;
-
-type DeleteCustomerActionErrorMessage =
-	| typeof INVALID_INPUT_ERROR_MESSAGE
-	| typeof UNAUTHORIZED_ERROR_MESSAGE
-	| typeof FORBIDDEN_ERROR_MESSAGE
-	| typeof CUSTOMER_NOT_FOUND_ERROR_MESSAGE
-	| typeof INTERNAL_SERVER_ERROR_MESSAGE;
 
 const deleteCustomerSchema = v.object({
 	customerId: v.pipe(v.string(), v.uuid()),
 });
 
-type DeleteCustomerInput = v.InferInput<typeof deleteCustomerSchema>;
-
-export async function deleteCustomerAction(
-	params: DeleteCustomerInput,
-): Promise<Result<undefined, DeleteCustomerActionErrorMessage>> {
-	const logger = await getLogger("deleteCustomerAction");
-	logger.info("deleteCustomerAction を実行", {
-		params,
-	});
-
-	// バリデーション
-	const paramsParseResult = v.safeParse(deleteCustomerSchema, params);
-	if (!paramsParseResult.success) {
-		logger.warn("バリデーション失敗", {
-			event: EventType.InputValidationError,
-			issues: paramsParseResult.issues,
-		});
-		return fail(INVALID_INPUT_ERROR_MESSAGE);
-	}
-
-	const { customerId } = paramsParseResult.output;
-
-	// 認証情報の取得
-	const userId = await getUserStaffId();
-	if (!userId) {
-		logger.warn("認証されていないアクセス", {
-			event: EventType.AuthenticationFailure,
-		});
-		return fail(UNAUTHORIZED_ERROR_MESSAGE);
-	}
-
-	const role = await getUserRole();
-	if (role !== "admin") {
-		logger.warn("権限がないアクセス", {
-			customerId,
-			event: EventType.AuthorizationError,
-		});
-		return fail(FORBIDDEN_ERROR_MESSAGE);
-	}
-
-	// 削除処理を実行
-	const result = await deleteCustomer({
-		customerId,
-	});
-
-	if (!result.success) {
-		return result;
-	}
-
-	// キャッシュの更新
-	updateTag(CustomerTag.crud);
-	updateTag(CustomerTag.NoteCrud(customerId));
-
-	redirect("/customers", RedirectType.replace);
-}
+export const deleteCustomerAction = createServerAction(deleteCustomer, {
+	name: "deleteCustomerAction",
+	onSuccess: ({ input }) => {
+		updateTag(CustomerTag.crud);
+		updateTag(CustomerTag.NoteCrud(input.customerId));
+		redirect("/customers", RedirectType.replace);
+	},
+	role: [UserRole.Admin],
+	schema: deleteCustomerSchema,
+});

--- a/apps/web/features/customer/edit/edit-customer-action.ts
+++ b/apps/web/features/customer/edit/edit-customer-action.ts
@@ -1,64 +1,25 @@
 "use server";
 
-import { fail, type Result, succeed } from "@harusame0616/result";
-import { EventType } from "@repo/logger/event-types";
-import { getLogger } from "@repo/logger/nextjs/server";
+import { succeed } from "@harusame0616/result";
 import { updateTag } from "next/cache";
-import { getUserStaffId } from "@/features/auth/get-user-staff-id";
 import { tagByCustomerId } from "@/features/customer/tag";
-import { type EditCustomerErrorMessage, editCustomer } from "./edit-customer";
-import { type EditCustomerParams, parseEditCustomerParams } from "./schema";
+import { createServerAction } from "@/libs/create-server-action";
+import { editCustomer } from "./edit-customer";
+import { editCustomerSchema } from "./schema";
 
-const INVALID_INPUT_ERROR_MESSAGE = "入力内容に誤りがあります" as const;
-const UNAUTHORIZED_ERROR_MESSAGE = "認証に失敗しました" as const;
-const INTERNAL_SERVER_ERROR_MESSAGE =
-	"サーバーエラーが発生しました。時間をおいて再度お試しください" as const;
-
-type EditCustomerActionErrorMessage =
-	| EditCustomerErrorMessage
-	| typeof INVALID_INPUT_ERROR_MESSAGE
-	| typeof UNAUTHORIZED_ERROR_MESSAGE
-	| typeof INTERNAL_SERVER_ERROR_MESSAGE;
-
-export async function editCustomerAction(
-	params: EditCustomerParams,
-): Promise<Result<{ customerId: string }, EditCustomerActionErrorMessage>> {
-	const logger = await getLogger("editCustomerAction");
-	logger.info("editCustomerAction を実行", {
-		params,
-	});
-
-	const parsedParams = parseEditCustomerParams(params);
-	if (!parsedParams.success) {
-		logger.warn("バリデーション失敗", {
-			error: parsedParams.error,
-			event: EventType.InputValidationError,
-		});
-		return fail(INVALID_INPUT_ERROR_MESSAGE);
-	}
-
-	const userId = await getUserStaffId();
-	if (!userId) {
-		logger.warn("認証されていないアクセス", {
-			event: EventType.AuthenticationFailure,
-		});
-		return fail(UNAUTHORIZED_ERROR_MESSAGE);
-	}
-
-	try {
-		const result = await editCustomer(parsedParams.data);
+export const editCustomerAction = createServerAction(
+	async (input) => {
+		const result = await editCustomer(input);
 		if (!result.success) {
 			return result;
 		}
-
-		updateTag(tagByCustomerId(parsedParams.data.customerId));
-		return succeed({ customerId: parsedParams.data.customerId });
-	} catch (error) {
-		logger.error("顧客編集中に予期しないエラーが発生", {
-			action: "edit-customer",
-			error,
-		});
-
-		return fail(INTERNAL_SERVER_ERROR_MESSAGE);
-	}
-}
+		return succeed({ customerId: input.customerId });
+	},
+	{
+		name: "editCustomerAction",
+		onSuccess: ({ input }) => {
+			updateTag(tagByCustomerId(input.customerId));
+		},
+		schema: editCustomerSchema,
+	},
+);

--- a/apps/web/features/customer/edit/edit-customer.ts
+++ b/apps/web/features/customer/edit/edit-customer.ts
@@ -8,14 +8,14 @@ import type { EditCustomerParams } from "./schema";
 const CUSTOMER_NOT_FOUND_ERROR_MESSAGE =
 	"指定された顧客が見つかりません" as const;
 
-export type EditCustomerErrorMessage = typeof CUSTOMER_NOT_FOUND_ERROR_MESSAGE;
-
 export async function editCustomer({
 	customerId,
 	email,
 	name,
 	phone,
-}: EditCustomerParams): Promise<Result<undefined, EditCustomerErrorMessage>> {
+}: EditCustomerParams): Promise<
+	Result<undefined, typeof CUSTOMER_NOT_FOUND_ERROR_MESSAGE>
+> {
 	const logger = await getLogger("editCustomer");
 
 	const customer = await db.query.customersTable.findFirst({

--- a/apps/web/features/customer/edit/schema.ts
+++ b/apps/web/features/customer/edit/schema.ts
@@ -1,8 +1,7 @@
-import { fail, type Result, succeed } from "@harusame0616/result";
 import * as v from "valibot";
 import { emailSchema, nameSchema, phoneSchema } from "../schema";
 
-const editCustomerSchema = v.object({
+export const editCustomerSchema = v.object({
 	customerId: v.pipe(v.string(), v.uuid()),
 	email: emailSchema,
 	name: nameSchema,
@@ -10,15 +9,3 @@ const editCustomerSchema = v.object({
 });
 
 export type EditCustomerParams = v.InferInput<typeof editCustomerSchema>;
-
-export function parseEditCustomerParams(
-	value: unknown,
-): Result<EditCustomerParams, Error> {
-	const result = v.safeParse(editCustomerSchema, value);
-
-	if (result.success) {
-		return succeed(result.output);
-	}
-
-	return fail(new v.ValiError(result.issues));
-}

--- a/apps/web/features/customer/register/register-customer-action.small.server.test.ts
+++ b/apps/web/features/customer/register/register-customer-action.small.server.test.ts
@@ -5,9 +5,13 @@ vi.mock("next/cache", async () => ({
 	updateTag: vi.fn(),
 }));
 
-vi.mock("next/navigation", () => ({
-	redirect: vi.fn(),
-}));
+vi.mock("next/navigation", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("next/navigation")>();
+	return {
+		...actual,
+		redirect: vi.fn(),
+	};
+});
 
 vi.mock("@repo/logger/nextjs/server", () => ({
 	getLogger: vi.fn().mockResolvedValue({
@@ -15,6 +19,14 @@ vi.mock("@repo/logger/nextjs/server", () => ({
 		info: vi.fn(),
 		warn: vi.fn(),
 	}),
+}));
+
+vi.mock("@/features/auth/get-user-staff-id", () => ({
+	getUserStaffId: vi.fn().mockResolvedValue("test-staff-id"),
+}));
+
+vi.mock("@/features/auth/get-user-role", () => ({
+	getUserRole: vi.fn().mockResolvedValue("user"),
 }));
 
 vi.mock("./register-customer", () => ({

--- a/apps/web/features/customer/register/register-customer-action.ts
+++ b/apps/web/features/customer/register/register-customer-action.ts
@@ -1,57 +1,16 @@
 "use server";
 
-import { fail, type Result, succeed } from "@harusame0616/result";
-import { EventType } from "@repo/logger/event-types";
-import { getLogger } from "@repo/logger/nextjs/server";
 import { updateTag } from "next/cache";
+import { createServerAction } from "@/libs/create-server-action";
 import { CustomerTag, tagByCustomerId } from "../tag";
 import { registerCustomer } from "./register-customer";
-import {
-	parseRegisterCustomerParams,
-	type RegisterCustomerParams,
-} from "./schema";
+import { registerCustomerSchema } from "./schema";
 
-const INVALID_INPUT_ERROR_MESSAGE = "入力内容に誤りがあります" as const;
-const INTERNAL_SERVER_ERROR_MESSAGE =
-	"サーバーエラーが発生しました。時間をおいて再度お試しください" as const;
-
-export async function registerCustomerAction(
-	params: RegisterCustomerParams,
-): Promise<
-	Result<
-		{ customerId: string },
-		typeof INTERNAL_SERVER_ERROR_MESSAGE | typeof INVALID_INPUT_ERROR_MESSAGE
-	>
-> {
-	const logger = await getLogger("registerCustomerAction");
-	logger.info("registerCustomerAction を実行", { params });
-
-	const parsedParams = parseRegisterCustomerParams(params);
-	if (!parsedParams.success) {
-		logger.warn("バリデーション失敗", {
-			event: EventType.InputValidationError,
-		});
-		return fail(INVALID_INPUT_ERROR_MESSAGE);
-	}
-
-	try {
-		const {
-			data: { customerId },
-		} = await registerCustomer(parsedParams.data);
-
-		logger.info("顧客登録に成功", {
-			action: "register-customer",
-			customerId,
-		});
-
+export const registerCustomerAction = createServerAction(registerCustomer, {
+	name: "registerCustomerAction",
+	onSuccess: ({ result }) => {
 		updateTag(CustomerTag.crud);
-		updateTag(tagByCustomerId(customerId));
-		return succeed({ customerId });
-	} catch (error) {
-		logger.error("顧客登録中に予期しないエラーが発生", {
-			action: "register-customer",
-			error,
-		});
-		return fail(INTERNAL_SERVER_ERROR_MESSAGE);
-	}
-}
+		updateTag(tagByCustomerId(result.customerId));
+	},
+	schema: registerCustomerSchema,
+});

--- a/apps/web/features/customer/register/schema.ts
+++ b/apps/web/features/customer/register/schema.ts
@@ -1,4 +1,3 @@
-import { fail, type Result, succeed } from "@harusame0616/result";
 import * as v from "valibot";
 import { emailSchema, nameSchema, phoneSchema } from "../schema";
 
@@ -11,15 +10,3 @@ export const registerCustomerSchema = v.object({
 export type RegisterCustomerParams = v.InferOutput<
 	typeof registerCustomerSchema
 >;
-
-export function parseRegisterCustomerParams(
-	value: unknown,
-): Result<RegisterCustomerParams, Error> {
-	const result = v.safeParse(registerCustomerSchema, value);
-
-	if (result.success) {
-		return succeed(result.output);
-	}
-
-	return fail(new v.ValiError(result.issues));
-}

--- a/apps/web/libs/create-server-action.ts
+++ b/apps/web/libs/create-server-action.ts
@@ -2,6 +2,7 @@ import { fail, type Result } from "@harusame0616/result";
 import { EventType } from "@repo/logger/event-types";
 import type { Logger } from "@repo/logger/logger";
 import { getLogger } from "@repo/logger/nextjs/server";
+import { unstable_rethrow } from "next/navigation";
 import type * as v from "valibot";
 import * as valibot from "valibot";
 import { getUserRole, type UserRole } from "@/features/auth/get-user-role";
@@ -141,6 +142,7 @@ export function createServerAction<
 
 			return result;
 		} catch (error) {
+			unstable_rethrow(error);
 			logger.error(`${options.name} で予期しないエラーが発生`, { err: error });
 			return fail(INTERNAL_SERVER_ERROR_MESSAGE);
 		}

--- a/apps/web/libs/create-server-action.ts
+++ b/apps/web/libs/create-server-action.ts
@@ -1,0 +1,148 @@
+import { fail, type Result } from "@harusame0616/result";
+import { EventType } from "@repo/logger/event-types";
+import type { Logger } from "@repo/logger/logger";
+import { getLogger } from "@repo/logger/nextjs/server";
+import type * as v from "valibot";
+import * as valibot from "valibot";
+import { getUserRole, type UserRole } from "@/features/auth/get-user-role";
+import { getUserStaffId } from "@/features/auth/get-user-staff-id";
+
+const VALIDATION_ERROR_MESSAGE = "入力内容に誤りがあります" as const;
+const UNAUTHORIZED_ERROR_MESSAGE = "認証に失敗しました" as const;
+const FORBIDDEN_ERROR_MESSAGE = "この操作を実行する権限がありません" as const;
+const INTERNAL_SERVER_ERROR_MESSAGE =
+	"サーバーエラーが発生しました。時間をおいて再度お試しください" as const;
+
+type ServerActionContext = {
+	logger: Logger;
+	role: UserRole | null;
+	userId: string | null;
+};
+
+type BaseOptions<
+	TSchema extends v.GenericSchema,
+	TData,
+	TError extends string,
+> = {
+	name: string;
+	schema?: TSchema;
+	onSuccess?: (args: {
+		input: v.InferOutput<TSchema>;
+		result: TData;
+	}) => void | Promise<void>;
+	onFailure?: (args: {
+		error: TError;
+		input: v.InferOutput<TSchema>;
+	}) => void | Promise<void>;
+};
+
+type PublicOptions<
+	TSchema extends v.GenericSchema,
+	TData,
+	TError extends string,
+> = BaseOptions<TSchema, TData, TError> & {
+	isPublic: true;
+};
+
+type PrivateOptions<
+	TSchema extends v.GenericSchema,
+	TData,
+	TError extends string,
+> = BaseOptions<TSchema, TData, TError> & {
+	isPublic?: false;
+	role?: UserRole[];
+};
+
+type ServerActionOptions<
+	TSchema extends v.GenericSchema,
+	TData,
+	TError extends string,
+> =
+	| PublicOptions<TSchema, TData, TError>
+	| PrivateOptions<TSchema, TData, TError>;
+
+type ServerActionErrorMessage =
+	| typeof VALIDATION_ERROR_MESSAGE
+	| typeof UNAUTHORIZED_ERROR_MESSAGE
+	| typeof FORBIDDEN_ERROR_MESSAGE
+	| typeof INTERNAL_SERVER_ERROR_MESSAGE;
+
+export function createServerAction<
+	TSchema extends v.GenericSchema,
+	TData,
+	TError extends string,
+>(
+	logicFunc: (
+		input: v.InferOutput<TSchema>,
+		context: ServerActionContext,
+	) => Promise<Result<TData, TError>>,
+	options: ServerActionOptions<TSchema, TData, TError>,
+): (
+	input: v.InferInput<TSchema>,
+) => Promise<Result<TData, TError | ServerActionErrorMessage>> {
+	return async (
+		input: v.InferInput<TSchema>,
+	): Promise<Result<TData, TError | ServerActionErrorMessage>> => {
+		const logger = await getLogger(options.name);
+		logger.info(`${options.name} を実行`, { input });
+
+		let validatedInput: v.InferOutput<TSchema> =
+			input as v.InferOutput<TSchema>;
+		if (options.schema) {
+			const parseResult = valibot.safeParse(options.schema, input);
+			if (!parseResult.success) {
+				logger.warn("バリデーション失敗", {
+					event: EventType.InputValidationError,
+					issues: parseResult.issues,
+				});
+				return fail(VALIDATION_ERROR_MESSAGE);
+			}
+			validatedInput = parseResult.output;
+		}
+
+		let userId: string | null = null;
+		let role: UserRole | null = null;
+		if (!options.isPublic) {
+			userId = await getUserStaffId();
+			if (!userId) {
+				logger.warn("認証されていないアクセス", {
+					event: EventType.AuthenticationFailure,
+				});
+				return fail(UNAUTHORIZED_ERROR_MESSAGE);
+			}
+
+			role = await getUserRole();
+			if ("role" in options && options.role && options.role.length > 0) {
+				if (!options.role.includes(role)) {
+					logger.warn("権限がないアクセス", {
+						event: EventType.AuthorizationError,
+					});
+					return fail(FORBIDDEN_ERROR_MESSAGE);
+				}
+			}
+		}
+
+		try {
+			const result = await logicFunc(validatedInput, { logger, role, userId });
+
+			if (result.success) {
+				logger.info(`${options.name} 成功`);
+				await options.onSuccess?.({
+					input: validatedInput,
+					result: result.data,
+				});
+			} else {
+				logger.warn(`${options.name} 失敗`, { error: result.error });
+				await options.onFailure?.({
+					error: result.error,
+					input: validatedInput,
+				});
+			}
+
+			return result;
+		} catch (error) {
+			logger.error(`${options.name} で予期しないエラーが発生`, { err: error });
+			return fail(INTERNAL_SERVER_ERROR_MESSAGE);
+		}
+	};
+}


### PR DESCRIPTION
## Summary
- Server Action の共通処理を抽象化する `createServerAction` ヘルパー関数を作成
- 既存の全 Server Action を `createServerAction` を使用するように置き換え
- 不要になった型エクスポートやパース関数を削除し、コードを大幅に簡素化（504行削除、286行追加）

## 主な機能
- **バリデーション**: valibot スキーマによる入力バリデーション
- **認証**: `isPublic` フラグで公開/認証必須を制御
- **認可**: `role` 配列で許可するロールを指定
- **コールバック**: `onSuccess({ input, result })` / `onFailure({ input, error })` 形式
- **ログ出力**: 開始・成功・失敗を自動ログ
- **例外処理**: 予期しない例外を自動キャッチしエラーログ出力
- **コンテキスト**: `logger`, `userId`, `role` を logicFunc に提供

## 置き換えた Server Actions
- `delete-customer-action.ts`
- `register-customer-action.ts`
- `edit-customer-action.ts`
- `login-action.ts`
- `register-customer-note-action.ts`
- `edit-customer-note-action.ts`
- `delete-customer-note-action.ts`
- `create-upload-url-action.ts`

## Test plan
- [ ] `pnpm validate:check` が通ること
- [ ] `pnpm build` が成功すること
- [ ] E2E テストが通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)