### PR TITLE
feat: スタッフ一覧ページの実装

### DIFF
--- a/apps/web/app/(private)/_components/navigation-menu.tsx
+++ b/apps/web/app/(private)/_components/navigation-menu.tsx
@@ -38,6 +38,15 @@ export function NavigationMenu() {
 								顧客一覧
 							</Link>
 						</li>
+						<li>
+							<Link
+								className="block rounded-md px-4 py-2 text-sm font-medium text-neutral-700 hover:bg-neutral-100 hover:text-neutral-900"
+								href="/staffs"
+								onClick={() => setOpen(false)}
+							>
+								スタッフ一覧
+							</Link>
+						</li>
 					</ul>
 				</nav>
 			</SheetContent>

--- a/apps/web/app/(private)/staffs/page.tsx
+++ b/apps/web/app/(private)/staffs/page.tsx
@@ -1,0 +1,33 @@
+import { Card } from "@workspace/ui/components/card";
+import { parseStaffsConditionSearchParams } from "@/features/staff/list/schema";
+import { StaffSearchFormContainer } from "@/features/staff/list/staff-search-form-container";
+import { StaffSearchForm } from "@/features/staff/list/staff-search-form-presenter";
+import { StaffsContainer } from "@/features/staff/list/staffs-container";
+import { StaffsSkeleton } from "@/features/staff/list/staffs-skeleton";
+import { SuspenseOnSearch } from "@/libs/suspense-on-search";
+
+export default function Page({ searchParams }: PageProps<"/staffs">) {
+	const validatedCondition = searchParams.then(
+		(params) => parseStaffsConditionSearchParams(params).data,
+	);
+
+	return (
+		<div className="container mx-auto p-2 space-y-4">
+			<div className="flex items-center justify-between">
+				<h1 className="font-bold">スタッフ一覧</h1>
+			</div>
+			<Card className="p-4 w-full">
+				<SuspenseOnSearch
+					fallback={<StaffSearchForm condition={{ keyword: "" }} />}
+				>
+					<StaffSearchFormContainer conditionPromise={validatedCondition} />
+				</SuspenseOnSearch>
+			</Card>
+			<Card className="py-2 w-full">
+				<SuspenseOnSearch fallback={<StaffsSkeleton />}>
+					<StaffsContainer condition={validatedCondition} />
+				</SuspenseOnSearch>
+			</Card>
+		</div>
+	);
+}

--- a/apps/web/e2e/staffs.e2e.test.ts
+++ b/apps/web/e2e/staffs.e2e.test.ts
@@ -1,0 +1,141 @@
+import { test as base, expect, type Page } from "@playwright/test";
+
+type StaffsPageFixture = {
+	staffsPage: Page;
+	authenticatedPage: Page;
+	testUser: {
+		email: string;
+		password: string;
+	};
+};
+
+const test = base.extend<StaffsPageFixture>({
+	authenticatedPage: async ({ page, testUser }, use) => {
+		await page.goto("/login");
+		await page.getByLabel("メールアドレス").fill(testUser.email);
+		await page
+			.getByRole("textbox", { name: "パスワード" })
+			.fill(testUser.password);
+		await page.getByRole("button", { name: "ログイン" }).click();
+		await page.waitForURL("/");
+
+		await use(page);
+	},
+	staffsPage: async ({ authenticatedPage }, use) => {
+		await authenticatedPage.goto("/staffs");
+		await authenticatedPage.waitForURL("/staffs");
+		await expect(
+			authenticatedPage.getByRole("main").getByText("読み込み中"),
+		).toBeHidden();
+
+		await use(authenticatedPage);
+	},
+	testUser: [
+		{
+			email: "test1@example.com",
+			password: "Test@Pass123",
+		},
+		{ option: true },
+	],
+});
+
+test("メニューからスタッフ一覧ページに遷移できる", async ({
+	authenticatedPage,
+}) => {
+	await test.step("メニューボタンをクリックしてメニューを開く", async () => {
+		await authenticatedPage
+			.getByRole("button", { name: /^メニューを開く$/ })
+			.click();
+	});
+
+	await test.step("スタッフ一覧リンクをクリック", async () => {
+		await authenticatedPage.getByRole("link", { name: "スタッフ一覧" }).click();
+	});
+
+	await test.step("スタッフ一覧ページに遷移することを確認", async () => {
+		await expect(authenticatedPage).toHaveURL("/staffs");
+		await expect(
+			authenticatedPage.getByRole("heading", { name: "スタッフ一覧" }),
+		).toBeVisible();
+	});
+});
+
+test("スタッフ一覧が表示される", async ({ staffsPage }) => {
+	await test.step("スタッフが表示されていることを確認", async () => {
+		const rows = staffsPage.locator("table tbody tr");
+		const count = await rows.count();
+		expect(count).toBeGreaterThan(0);
+	});
+
+	await test.step("名前とメールアドレスが表示されていることを確認", async () => {
+		await expect(staffsPage.getByText("田中 太郎")).toBeVisible();
+		await expect(
+			staffsPage.getByText("tanaka@staff.example.com"),
+		).toBeVisible();
+	});
+});
+
+test("名前で検索できる", async ({ staffsPage }) => {
+	const searchKeyword = "田中";
+
+	await test.step("名前を入力して検索", async () => {
+		await staffsPage.getByLabel("検索キーワード").fill(searchKeyword);
+		await staffsPage.getByRole("button", { name: "検索" }).click();
+		await staffsPage.waitForURL("**/staffs?keyword=*");
+		await expect(
+			staffsPage.getByRole("main").getByText("読み込み中"),
+		).toBeHidden();
+	});
+
+	await test.step("検索結果を確認", async () => {
+		const rows = staffsPage.locator("table tbody tr");
+		const count = await rows.count();
+		for (let i = 0; i < count; i++) {
+			const row = rows.nth(i);
+			const text = await row.textContent();
+			expect(text).toContain(searchKeyword);
+		}
+	});
+});
+
+test("メールアドレスで検索できる", async ({ staffsPage }) => {
+	const searchKeyword = "yamada";
+
+	await test.step("メールアドレスで検索", async () => {
+		await staffsPage.getByLabel("検索キーワード").fill(searchKeyword);
+		await staffsPage.getByRole("button", { name: "検索" }).click();
+		await staffsPage.waitForURL("**/staffs?keyword=*");
+		await expect(
+			staffsPage.getByRole("main").getByText("読み込み中"),
+		).toBeHidden();
+	});
+
+	await test.step("検索結果を確認", async () => {
+		const rows = staffsPage.locator("table tbody tr");
+		const count = await rows.count();
+		for (let i = 0; i < count; i++) {
+			const row = rows.nth(i);
+			const text = await row.textContent();
+			expect(text).toContain(searchKeyword);
+		}
+	});
+});
+
+test("該当するスタッフがいない場合、メッセージが表示される", async ({
+	staffsPage,
+}) => {
+	await test.step("存在しないキーワードで検索", async () => {
+		await staffsPage.getByLabel("検索キーワード").fill("存在しないスタッフ");
+		await staffsPage.getByRole("button", { name: "検索" }).click();
+		await staffsPage.waitForURL("**/staffs?keyword=*");
+		await expect(
+			staffsPage.getByRole("main").getByText("読み込み中"),
+		).toBeHidden();
+	});
+
+	await test.step("メッセージを確認", async () => {
+		await expect(
+			staffsPage.getByText("スタッフが見つかりませんでした"),
+		).toBeVisible();
+	});
+});

--- a/apps/web/features/staff/list/get-staffs.medium.server.test.ts
+++ b/apps/web/features/staff/list/get-staffs.medium.server.test.ts
@@ -1,0 +1,60 @@
+import { db } from "@workspace/db/client";
+import { staffsTable } from "@workspace/db/schema/staff";
+import { eq } from "drizzle-orm";
+import { v4 } from "uuid";
+import { test as base, expect, vi } from "vitest";
+import { getStaffs } from "./get-staffs";
+
+vi.mock("next/cache", () => ({
+	cacheLife: vi.fn(),
+	cacheTag: vi.fn(),
+}));
+
+const test = base.extend<{
+	staff: {
+		id: string;
+		email: string;
+		name: string;
+	};
+}>({
+	// biome-ignore lint/correctness/noEmptyPattern: The first argument inside a fixture must use object destructuring pattern, e.g. ({ test } => {}). Instead, received "_".
+	async staff({}, use) {
+		const staff = {
+			email: `${v4()}@staff.example.com`,
+			id: v4(),
+			name: v4().slice(0, 24),
+		};
+
+		await db.insert(staffsTable).values(staff);
+		await use(staff);
+		await db.delete(staffsTable).where(eq(staffsTable.id, staff.id));
+	},
+});
+
+test("複数フィールドにマッチする検索ができる", async ({ staff }) => {
+	const emailSearchResult = await getStaffs({
+		keyword: staff.email,
+		page: 1,
+	});
+	const nameSearchResult = await getStaffs({
+		keyword: staff.name,
+		page: 1,
+	});
+
+	expect(emailSearchResult.staffs.length).toBe(1);
+	expect(nameSearchResult.staffs.length).toBe(1);
+});
+
+test("大文字小文字を区別せずに検索できる", async ({ staff }) => {
+	const emailSearchResult = await getStaffs({
+		keyword: staff.email.toUpperCase(),
+		page: 1,
+	});
+	const nameSearchResult = await getStaffs({
+		keyword: staff.name.toUpperCase(),
+		page: 1,
+	});
+
+	expect(emailSearchResult.staffs.length).toBe(1);
+	expect(nameSearchResult.staffs.length).toBe(1);
+});

--- a/apps/web/features/staff/list/get-staffs.ts
+++ b/apps/web/features/staff/list/get-staffs.ts
@@ -1,0 +1,46 @@
+import { db } from "@workspace/db/client";
+import type { SelectStaff } from "@workspace/db/schema/staff";
+import { staffsTable } from "@workspace/db/schema/staff";
+import { desc, ilike, or } from "drizzle-orm";
+import { cacheLife, cacheTag } from "next/cache";
+import { StaffTag } from "../tag";
+import type { StaffsCondition } from "./schema";
+
+type GetStaffsResult = {
+	staffs: SelectStaff[];
+	page: number;
+	totalPages: number;
+};
+
+export async function getStaffs({
+	keyword,
+	page,
+}: StaffsCondition): Promise<GetStaffsResult> {
+	"use cache";
+	cacheLife("permanent");
+	cacheTag(StaffTag.Crud);
+
+	const pageSize = 20;
+	const whereConditions = keyword
+		? or(
+				ilike(staffsTable.name, `%${keyword}%`),
+				ilike(staffsTable.email, `%${keyword}%`),
+			)
+		: undefined;
+
+	const staffs = await db
+		.select()
+		.from(staffsTable)
+		.where(whereConditions)
+		.orderBy(desc(staffsTable.createdAt))
+		.limit(pageSize)
+		.offset((page - 1) * pageSize);
+
+	const total = await db.$count(staffsTable, whereConditions);
+
+	return {
+		page,
+		staffs,
+		totalPages: Math.ceil(total / pageSize),
+	};
+}

--- a/apps/web/features/staff/list/schema.ts
+++ b/apps/web/features/staff/list/schema.ts
@@ -1,0 +1,41 @@
+import { succeed } from "@harusame0616/result";
+import * as v from "valibot";
+
+export const STAFF_SEARCH_KEYWORD_MAX_LENGTH = 300;
+
+const keywordSchema = v.pipe(
+	v.string(),
+	v.maxLength(STAFF_SEARCH_KEYWORD_MAX_LENGTH),
+);
+
+const pageSchema = v.pipe(v.number(), v.minValue(1));
+
+export const staffsConditionSchema = v.object({
+	keyword: keywordSchema,
+	page: pageSchema,
+});
+
+const staffsConditionSearchParamsSchema = v.object({
+	keyword: v.optional(keywordSchema, ""),
+	page: v.optional(v.pipe(v.string(), v.transform(Number), pageSchema), "1"),
+});
+
+export type StaffsConditionSearchParams = v.InferOutput<
+	typeof staffsConditionSearchParamsSchema
+>;
+
+export type StaffsCondition = v.InferOutput<typeof staffsConditionSchema>;
+
+export function parseStaffsConditionSearchParams(value: unknown) {
+	const result = v.safeParse(staffsConditionSearchParamsSchema, value);
+
+	return result.success
+		? succeed(result.output)
+		: succeed({ keyword: "", page: 1 });
+}
+
+export type StaffsListItem = {
+	id: string;
+	name: string;
+	email: string;
+};

--- a/apps/web/features/staff/list/staff-search-form-container.tsx
+++ b/apps/web/features/staff/list/staff-search-form-container.tsx
@@ -1,0 +1,10 @@
+import type { StaffsConditionSearchParams } from "./schema";
+import { StaffSearchForm } from "./staff-search-form-presenter";
+
+export async function StaffSearchFormContainer({
+	conditionPromise,
+}: {
+	conditionPromise: Promise<Omit<StaffsConditionSearchParams, "page">>;
+}) {
+	return <StaffSearchForm condition={await conditionPromise} />;
+}

--- a/apps/web/features/staff/list/staff-search-form-presenter.tsx
+++ b/apps/web/features/staff/list/staff-search-form-presenter.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { valibotResolver } from "@hookform/resolvers/valibot";
+import { Button } from "@workspace/ui/components/button";
+import {
+	Form,
+	FormControl,
+	FormDescription,
+	FormField,
+	FormItem,
+	FormLabel,
+	FormMessage,
+} from "@workspace/ui/components/form";
+import { Input } from "@workspace/ui/components/input";
+import { Search } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import * as v from "valibot";
+import { useIsHydrated } from "@/libs/use-is-hydrated";
+import {
+	STAFF_SEARCH_KEYWORD_MAX_LENGTH,
+	staffsConditionSchema,
+} from "./schema";
+
+export const formSchema = v.omit(staffsConditionSchema, ["page"]);
+
+export function StaffSearchForm({
+	condition,
+}: {
+	condition: v.InferInput<typeof formSchema>;
+}) {
+	const router = useRouter();
+	const { isHydrated } = useIsHydrated();
+
+	const form = useForm<v.InferInput<typeof formSchema>>({
+		defaultValues: { keyword: condition.keyword },
+		resolver: valibotResolver(formSchema),
+	});
+
+	function onSubmit({ keyword }: v.InferOutput<typeof formSchema>) {
+		const params = new URLSearchParams();
+		if (keyword) {
+			params.set("keyword", keyword);
+		}
+
+		router.push(`/staffs?${params}`);
+	}
+
+	return (
+		<Form {...form}>
+			<form onSubmit={form.handleSubmit(onSubmit)}>
+				<FormField
+					control={form.control}
+					name="keyword"
+					render={({ field }) => (
+						<FormItem>
+							<FormLabel>検索キーワード</FormLabel>
+							<FormDescription>
+								名前、メールアドレス（最大
+								{STAFF_SEARCH_KEYWORD_MAX_LENGTH}文字）
+							</FormDescription>
+							<div className="flex gap-4 items-center">
+								<FormControl>
+									<Input
+										{...field}
+										disabled={!isHydrated}
+										maxLength={STAFF_SEARCH_KEYWORD_MAX_LENGTH}
+										type="text"
+									/>
+								</FormControl>
+								<Button disabled={!isHydrated} type="submit">
+									<Search className="mr-2 h-4 w-4" />
+									検索
+								</Button>
+							</div>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+			</form>
+		</Form>
+	);
+}

--- a/apps/web/features/staff/list/staff-search-form.browser.test.tsx
+++ b/apps/web/features/staff/list/staff-search-form.browser.test.tsx
@@ -1,0 +1,27 @@
+import { expect, test, vi } from "vitest";
+import { page, userEvent } from "vitest/browser";
+import { render } from "vitest-browser-react";
+import { StaffSearchForm } from "./staff-search-form-presenter";
+
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({
+		push: vi.fn(),
+	}),
+	useSearchParams: () => ({
+		get: vi.fn(),
+	}),
+}));
+
+const MAX_KEYWORD_LENGTH = 300;
+
+test("最大文字数を超えて入力できない", async () => {
+	render(<StaffSearchForm condition={{ keyword: "" }} />);
+
+	const input = page.getByLabelText("検索キーワード");
+
+	const overLimitText = "あ".repeat(MAX_KEYWORD_LENGTH + 1);
+
+	await userEvent.fill(input, overLimitText);
+
+	await expect.element(input).toHaveValue("あ".repeat(MAX_KEYWORD_LENGTH));
+});

--- a/apps/web/features/staff/list/staffs-container.tsx
+++ b/apps/web/features/staff/list/staffs-container.tsx
@@ -1,0 +1,15 @@
+import { getStaffs } from "./get-staffs";
+import type { StaffsCondition } from "./schema";
+import { StaffsPresenter } from "./staffs-presenter";
+
+export async function StaffsContainer({
+	condition,
+}: {
+	condition: Promise<StaffsCondition>;
+}) {
+	const { staffs, page, totalPages } = await getStaffs(await condition);
+
+	return (
+		<StaffsPresenter page={page} staffs={staffs} totalPages={totalPages} />
+	);
+}

--- a/apps/web/features/staff/list/staffs-presenter.browser.test.tsx
+++ b/apps/web/features/staff/list/staffs-presenter.browser.test.tsx
@@ -1,0 +1,72 @@
+import { expect, test, vi } from "vitest";
+import { page } from "vitest/browser";
+import { render } from "vitest-browser-react";
+import type { StaffsListItem } from "./schema";
+import { StaffsPresenter } from "./staffs-presenter";
+
+vi.mock("next/navigation", () => ({
+	usePathname: vi.fn().mockReturnValue("path"),
+	useRouter: vi.fn().mockReturnValue({
+		push: vi.fn(),
+	}),
+	useSearchParams: vi.fn().mockReturnValue(new URLSearchParams()),
+}));
+
+const mockStaffs: StaffsListItem[] = [
+	{
+		email: "staff1@example.com",
+		id: "1",
+		name: "スタッフ1",
+	},
+	{
+		email: "staff2@example.com",
+		id: "2",
+		name: "スタッフ2",
+	},
+];
+
+test("スタッフ一覧が表示される", async () => {
+	render(<StaffsPresenter page={1} staffs={mockStaffs} totalPages={1} />);
+
+	await expect.element(page.getByText("スタッフ1")).toBeInTheDocument();
+	await expect.element(page.getByText("スタッフ2")).toBeInTheDocument();
+	await expect
+		.element(page.getByText("staff1@example.com"))
+		.toBeInTheDocument();
+	await expect
+		.element(page.getByText("staff2@example.com"))
+		.toBeInTheDocument();
+});
+
+test("スタッフが0件の場合、空のメッセージが表示される", async () => {
+	render(<StaffsPresenter page={1} staffs={[]} totalPages={0} />);
+
+	await expect
+		.element(page.getByText("スタッフが見つかりませんでした"))
+		.toBeInTheDocument();
+});
+
+test("ページネーションが表示される", async () => {
+	render(<StaffsPresenter page={2} staffs={mockStaffs} totalPages={3} />);
+
+	const paginationElement = page.getByRole("navigation");
+	await expect.element(paginationElement).toBeInTheDocument();
+});
+
+test("ページネーションが1ページのみの場合全てのボタンがdisabled", async () => {
+	render(<StaffsPresenter page={1} staffs={mockStaffs} totalPages={1} />);
+
+	const paginationElement = page.getByRole("navigation");
+	await expect.element(paginationElement).toBeInTheDocument();
+
+	const previousButton = page.getByRole("link", { name: "前へ" });
+	await expect.element(previousButton).toHaveAttribute("aria-disabled", "true");
+
+	const pageButton = page.getByRole("link", {
+		name: /^1$/,
+	});
+	await expect.element(pageButton).toHaveAttribute("aria-disabled", "true");
+
+	const nextButton = page.getByRole("link", { name: "次へ" });
+	await expect.element(nextButton).toHaveAttribute("aria-disabled", "true");
+});

--- a/apps/web/features/staff/list/staffs-presenter.tsx
+++ b/apps/web/features/staff/list/staffs-presenter.tsx
@@ -1,0 +1,55 @@
+import { SearchPagination } from "@workspace/ui/components/search-pagination";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@workspace/ui/components/table";
+import type { StaffsListItem } from "./schema";
+
+type StaffsPresenterProps = {
+	staffs: StaffsListItem[];
+	page: number;
+	totalPages: number;
+};
+
+export function StaffsPresenter({
+	staffs,
+	page,
+	totalPages,
+}: StaffsPresenterProps) {
+	if (!staffs.length) {
+		return (
+			<div className="space-y-4">
+				<div className="text-center py-8 text-muted-foreground">
+					スタッフが見つかりませんでした
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="space-y-4">
+			<Table>
+				<TableHeader>
+					<TableRow>
+						<TableHead>名前</TableHead>
+						<TableHead>メールアドレス</TableHead>
+					</TableRow>
+				</TableHeader>
+				<TableBody>
+					{staffs.map((staff) => (
+						<TableRow key={staff.id}>
+							<TableCell>{staff.name}</TableCell>
+							<TableCell>{staff.email}</TableCell>
+						</TableRow>
+					))}
+				</TableBody>
+			</Table>
+
+			<SearchPagination currentPage={page} totalPages={totalPages} />
+		</div>
+	);
+}

--- a/apps/web/features/staff/list/staffs-skeleton.tsx
+++ b/apps/web/features/staff/list/staffs-skeleton.tsx
@@ -1,0 +1,66 @@
+import {
+	Pagination,
+	PaginationContent,
+	PaginationItem,
+} from "@workspace/ui/components/pagination";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@workspace/ui/components/table";
+
+function SkeletonBox({ className = "" }: { className?: string }) {
+	return (
+		<div
+			aria-hidden="true"
+			className={`animate-pulse bg-muted rounded ${className}`}
+		/>
+	);
+}
+
+export function StaffsSkeleton() {
+	return (
+		<div className="space-y-4">
+			<div className="sr-only">読み込み中</div>
+			<Table aria-hidden>
+				<TableHeader>
+					<TableRow>
+						<TableHead>名前</TableHead>
+						<TableHead>メールアドレス</TableHead>
+					</TableRow>
+				</TableHeader>
+				<TableBody>
+					{Array.from({ length: 5 }).map((_, index) => (
+						<TableRow key={index}>
+							<TableCell>
+								<SkeletonBox className="h-5 w-32" />
+							</TableCell>
+							<TableCell>
+								<SkeletonBox className="h-5 w-48" />
+							</TableCell>
+						</TableRow>
+					))}
+				</TableBody>
+			</Table>
+
+			<Pagination>
+				<PaginationContent>
+					<PaginationItem>
+						<SkeletonBox className="h-10 w-20" />
+					</PaginationItem>
+					{Array.from({ length: 5 }).map((_, index) => (
+						<PaginationItem key={index}>
+							<SkeletonBox className="h-10 w-10" />
+						</PaginationItem>
+					))}
+					<PaginationItem>
+						<SkeletonBox className="h-10 w-20" />
+					</PaginationItem>
+				</PaginationContent>
+			</Pagination>
+		</div>
+	);
+}

--- a/apps/web/features/staff/tag.ts
+++ b/apps/web/features/staff/tag.ts
@@ -1,0 +1,3 @@
+export const StaffTag = {
+	Crud: "STAFF_TAG_CRUD",
+};

--- a/packages/db/drizzle/0008_melodic_zemo.sql
+++ b/packages/db/drizzle/0008_melodic_zemo.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "staffs" ADD COLUMN "email" text NOT NULL;

--- a/packages/db/drizzle/meta/0008_snapshot.json
+++ b/packages/db/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,292 @@
+{
+  "id": "47386a7c-f43f-4541-aecf-863ae59e8712",
+  "prevId": "233ad109-9e30-4216-9e21-888d7ed128ec",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.customers": {
+      "name": "customers",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_note_images": {
+      "name": "customer_note_images",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "customer_note_id": {
+          "name": "customer_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "customer_note_images_customer_note_id_customer_notes_id_fk": {
+          "name": "customer_note_images_customer_note_id_customer_notes_id_fk",
+          "tableFrom": "customer_note_images",
+          "tableTo": "customer_notes",
+          "columnsFrom": [
+            "customer_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "customer_note_images_customer_note_id_display_order_pk": {
+          "name": "customer_note_images_customer_note_id_display_order_pk",
+          "columns": [
+            "customer_note_id",
+            "display_order"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_notes": {
+      "name": "customer_notes",
+      "schema": "",
+      "columns": {
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "staff_id": {
+          "name": "staff_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_customer_notes_customer_created": {
+          "name": "idx_customer_notes_customer_created",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_notes_staff_id": {
+          "name": "idx_customer_notes_staff_id",
+          "columns": [
+            {
+              "expression": "staff_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_notes_customer_id_customers_customer_id_fk": {
+          "name": "customer_notes_customer_id_customers_customer_id_fk",
+          "tableFrom": "customer_notes",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "customer_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_notes_staff_id_staffs_id_fk": {
+          "name": "customer_notes_staff_id_staffs_id_fk",
+          "tableFrom": "customer_notes",
+          "tableTo": "staffs",
+          "columnsFrom": [
+            "staff_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staffs": {
+      "name": "staffs",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1764022817143,
       "tag": "0007_aberrant_jetstream",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1764167277439,
+      "tag": "0008_melodic_zemo",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/staff.ts
+++ b/packages/db/src/schema/staff.ts
@@ -2,6 +2,7 @@ import { pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
 
 export const staffsTable = pgTable("staffs", {
 	createdAt: timestamp("created_at").defaultNow().notNull(),
+	email: text("email").notNull(),
 	id: uuid("id").primaryKey().defaultRandom(),
 	name: text("name").notNull(),
 	updatedAt: timestamp("updated_at")

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -162,14 +162,17 @@ const customerSeeds = [
 // スタッフのseedデータ
 const staffSeeds = [
 	{
+		email: "tanaka@staff.example.com",
 		id: "00000000-0000-0000-0000-000000000001",
 		name: "田中 太郎",
 	},
 	{
+		email: "yamada@staff.example.com",
 		id: "00000000-0000-0000-0000-000000000002",
 		name: "山田 花子",
 	},
 	{
+		email: "sato@staff.example.com",
 		id: "00000000-0000-0000-0000-000000000003",
 		name: "佐藤 次郎",
 	},


### PR DESCRIPTION
## Summary
- staffsテーブルにemailカラムを追加し、マイグレーションを実行
- スタッフ一覧ページを顧客一覧と同様のContainer/Presenterパターンで実装
- キーワード検索（名前・メールアドレス対象）とページネーションに対応

## 変更内容
### データベース
- `staffs`テーブルに`email`カラムを追加
- シードデータにメールアドレスを追加

### 機能
- `/staffs` - スタッフ一覧ページ
- 名前・メールアドレスのテーブル表示
- キーワード検索（名前・メールアドレスから検索可能）
- ページネーション
- Cache Componentsによるキャッシュ

### ファイル構成
```
apps/web/features/staff/
├── tag.ts
├── list/
│   ├── schema.ts
│   ├── get-staffs.ts
│   ├── staffs-container.tsx
│   ├── staffs-presenter.tsx
│   ├── staffs-skeleton.tsx
│   ├── staff-search-form-container.tsx
│   └── staff-search-form-presenter.tsx
```

## Test plan
- [x] サーバーテスト（get-staffs.medium.server.test.ts）
- [x] ブラウザテスト（staff-search-form.browser.test.tsx, staffs-presenter.browser.test.tsx）
- [x] E2Eテスト（staffs.e2e.test.ts）

🤖 Generated with [Claude Code](https://claude.com/claude-code)