### PR TITLE
feat: スタッフ登録機能の実装

### DIFF
--- a/apps/web/app/(private)/staffs/new/page.tsx
+++ b/apps/web/app/(private)/staffs/new/page.tsx
@@ -1,0 +1,13 @@
+import { Card } from "@workspace/ui/components/card";
+import { EditStaffForm } from "@/features/staff/register/edit-staff-form";
+
+export default function NewStaffPage() {
+	return (
+		<div className="container mx-auto p-2 space-y-4">
+			<h1 className="font-bold">新規スタッフ登録</h1>
+			<Card className="p-4 w-full">
+				<EditStaffForm />
+			</Card>
+		</div>
+	);
+}

--- a/apps/web/app/(private)/staffs/page.tsx
+++ b/apps/web/app/(private)/staffs/page.tsx
@@ -1,4 +1,7 @@
 import { Card } from "@workspace/ui/components/card";
+import { Skeleton } from "@workspace/ui/components/skeleton";
+import { Suspense } from "react";
+import { RegisterStaffLink } from "@/features/staff/list/register-staff-link";
 import { parseStaffsConditionSearchParams } from "@/features/staff/list/schema";
 import { StaffSearchFormContainer } from "@/features/staff/list/staff-search-form-container";
 import { StaffSearchForm } from "@/features/staff/list/staff-search-form-presenter";
@@ -6,7 +9,7 @@ import { StaffsContainer } from "@/features/staff/list/staffs-container";
 import { StaffsSkeleton } from "@/features/staff/list/staffs-skeleton";
 import { SuspenseOnSearch } from "@/libs/suspense-on-search";
 
-export default function Page({ searchParams }: PageProps<"/staffs">) {
+export default async function Page({ searchParams }: PageProps<"/staffs">) {
 	const validatedCondition = searchParams.then(
 		(params) => parseStaffsConditionSearchParams(params).data,
 	);
@@ -15,6 +18,9 @@ export default function Page({ searchParams }: PageProps<"/staffs">) {
 		<div className="container mx-auto p-2 space-y-4">
 			<div className="flex items-center justify-between">
 				<h1 className="font-bold">スタッフ一覧</h1>
+				<Suspense fallback={<Skeleton className="h-5 w-16" />}>
+					<RegisterStaffLink />
+				</Suspense>
 			</div>
 			<Card className="p-4 w-full">
 				<SuspenseOnSearch

--- a/apps/web/e2e/staff-register.e2e.test.ts
+++ b/apps/web/e2e/staff-register.e2e.test.ts
@@ -1,0 +1,164 @@
+import { randomUUID } from "node:crypto";
+import { test as base, expect, type Page } from "@playwright/test";
+
+type RegisterStaffPageFixture = {
+	registerStaffPage: Page;
+};
+
+const test = base.extend<RegisterStaffPageFixture>({
+	registerStaffPage: async ({ page }, use) => {
+		const adminUser = {
+			email: "admin@example.com",
+			password: "Admin@789!",
+		};
+
+		await page.goto("/login");
+		await page.getByLabel("メールアドレス").fill(adminUser.email);
+		await page
+			.getByRole("textbox", { name: "パスワード" })
+			.fill(adminUser.password);
+		await page.getByRole("button", { name: "ログイン" }).click();
+		await page.waitForURL("/");
+
+		await page.goto("/staffs/new");
+		await page.waitForURL("/staffs/new");
+
+		await expect(page.getByLabel("名前")).not.toBeDisabled();
+
+		await use(page);
+	},
+});
+
+test("全フィールドを境界値一杯で入力してスタッフを登録し、一覧画面で検索できる", async ({
+	registerStaffPage,
+}) => {
+	const uniqueId = randomUUID().slice(0, 8);
+	const testData = {
+		email: `staff-${uniqueId}@example.com`,
+		name: `テスト太郎${uniqueId}`.slice(0, 24),
+		password: "TestPassword123!",
+		role: "admin" as const,
+	};
+
+	await test.step("フォームに境界値一杯のデータを入力", async () => {
+		await registerStaffPage.getByLabel("名前").fill(testData.name);
+		await registerStaffPage.getByLabel("メールアドレス").fill(testData.email);
+		await registerStaffPage
+			.getByRole("textbox", { name: "パスワード" })
+			.fill(testData.password);
+		await registerStaffPage.getByRole("radio", { name: "管理者" }).click();
+	});
+
+	await test.step("登録ボタンをクリック", async () => {
+		await registerStaffPage.getByRole("button", { name: "登録する" }).click();
+	});
+
+	await test.step("一覧ページに遷移することを確認", async () => {
+		await registerStaffPage.waitForURL("/staffs");
+		await expect(
+			registerStaffPage.getByRole("heading", { name: "スタッフ一覧" }),
+		).toBeVisible();
+	});
+
+	await test.step("登録したスタッフを検索", async () => {
+		await registerStaffPage.getByLabel("検索キーワード").fill(testData.name);
+		await registerStaffPage.getByRole("button", { name: "検索" }).click();
+		await registerStaffPage.waitForURL("**/staffs?keyword=*");
+		await expect(
+			registerStaffPage.getByRole("main").getByText("読み込み中"),
+		).toBeHidden();
+	});
+
+	await test.step("検索結果に登録したスタッフが表示されることを確認", async () => {
+		await expect(registerStaffPage.getByText(testData.name)).toBeVisible();
+		await expect(registerStaffPage.getByText(testData.email)).toBeVisible();
+	});
+});
+
+test("一般ロールでスタッフを登録できる", async ({ registerStaffPage }) => {
+	const uniqueId = randomUUID().slice(0, 8);
+	const testData = {
+		email: `user-${uniqueId}@example.com`,
+		name: `一般ユーザー${uniqueId}`.slice(0, 24),
+		password: "UserPassword123!",
+	};
+
+	await test.step("フォームにデータを入力（ロールは一般のまま）", async () => {
+		await registerStaffPage.getByLabel("名前").fill(testData.name);
+		await registerStaffPage.getByLabel("メールアドレス").fill(testData.email);
+		await registerStaffPage
+			.getByRole("textbox", { name: "パスワード" })
+			.fill(testData.password);
+	});
+
+	await test.step("一般ロールが選択されていることを確認", async () => {
+		await expect(
+			registerStaffPage.getByRole("radio", { name: "一般" }),
+		).toBeChecked();
+	});
+
+	await test.step("登録ボタンをクリック", async () => {
+		await registerStaffPage.getByRole("button", { name: "登録する" }).click();
+	});
+
+	await test.step("一覧ページに遷移することを確認", async () => {
+		await registerStaffPage.waitForURL("/staffs");
+	});
+
+	await test.step("登録したスタッフを検索", async () => {
+		await registerStaffPage.getByLabel("検索キーワード").fill(testData.name);
+		await registerStaffPage.getByRole("button", { name: "検索" }).click();
+		await registerStaffPage.waitForURL("**/staffs?keyword=*");
+		await expect(
+			registerStaffPage.getByRole("main").getByText("読み込み中"),
+		).toBeHidden();
+	});
+
+	await test.step("検索結果に登録したスタッフが表示されることを確認", async () => {
+		await expect(registerStaffPage.getByText(testData.name)).toBeVisible();
+		await expect(registerStaffPage.getByText(testData.email)).toBeVisible();
+	});
+});
+
+test("重複するメールアドレスで登録するとエラーが表示される", async ({
+	registerStaffPage,
+}) => {
+	const testData = {
+		email: "tanaka@staff.example.com",
+		name: "重複テスト",
+		password: "TestPassword123!",
+	};
+
+	await test.step("既存のメールアドレスでフォームを入力", async () => {
+		await registerStaffPage.getByLabel("名前").fill(testData.name);
+		await registerStaffPage.getByLabel("メールアドレス").fill(testData.email);
+		await registerStaffPage
+			.getByRole("textbox", { name: "パスワード" })
+			.fill(testData.password);
+	});
+
+	await test.step("登録ボタンをクリック", async () => {
+		await registerStaffPage.getByRole("button", { name: "登録する" }).click();
+	});
+
+	await test.step("エラーメッセージが表示されることを確認", async () => {
+		await expect(registerStaffPage.getByRole("alert")).toBeVisible();
+		await expect(
+			registerStaffPage.getByText("このメールアドレスは既に登録されています"),
+		).toBeVisible();
+	});
+
+	await test.step("新規登録ページに留まることを確認", async () => {
+		await expect(registerStaffPage).toHaveURL("/staffs/new");
+	});
+});
+
+test("キャンセルボタンで前のページに戻れる", async ({ registerStaffPage }) => {
+	await test.step("キャンセルボタンをクリック", async () => {
+		await registerStaffPage.getByRole("button", { name: "キャンセル" }).click();
+	});
+
+	await test.step("新規登録ページから離れることを確認", async () => {
+		await expect(registerStaffPage).not.toHaveURL("/staffs/new");
+	});
+});

--- a/apps/web/features/auth/get-user-role.ts
+++ b/apps/web/features/auth/get-user-role.ts
@@ -1,11 +1,7 @@
 import { createClient } from "@repo/supabase/nextjs/server";
+import { UserRole } from "./user/role";
 
-export const UserRole = {
-	Admin: "admin",
-	User: "user",
-} as const;
-
-export type UserRole = (typeof UserRole)[keyof typeof UserRole];
+export { UserRole } from "./user/role";
 
 export async function getUserRole(): Promise<UserRole> {
 	const supabase = await createClient();

--- a/apps/web/features/auth/user/role.ts
+++ b/apps/web/features/auth/user/role.ts
@@ -1,0 +1,6 @@
+export const UserRole = {
+	Admin: "admin",
+	User: "user",
+} as const;
+
+export type UserRole = (typeof UserRole)[keyof typeof UserRole];

--- a/apps/web/features/staff/list/register-staff-link.tsx
+++ b/apps/web/features/staff/list/register-staff-link.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link";
+import { getUserRole, UserRole } from "@/features/auth/get-user-role";
+
+export async function RegisterStaffLink() {
+	const role = await getUserRole();
+
+	if (role === UserRole.Admin) {
+		return (
+			<Link className="text-primary underline" href="/staffs/new">
+				新規登録
+			</Link>
+		);
+	}
+
+	return null;
+}

--- a/apps/web/features/staff/register/edit-staff-form.browser.test.tsx
+++ b/apps/web/features/staff/register/edit-staff-form.browser.test.tsx
@@ -1,0 +1,206 @@
+import type { Mock } from "vitest";
+import { test as base, expect, vi } from "vitest";
+import { page } from "vitest/browser";
+import { render } from "vitest-browser-react";
+import { EditStaffForm } from "./edit-staff-form";
+
+vi.mock("./register-staff-action", () => ({
+	registerStaffAction: vi.fn(),
+}));
+
+const test = base.extend<{
+	registerStaffActionMock: Mock;
+}>({
+	registerStaffActionMock: async (
+		// biome-ignore lint/correctness/noEmptyPattern: Vitestのfixtureパターンで使用する標準的な記法
+		{},
+		// biome-ignore lint/suspicious/noExplicitAny: https://github.com/vitest-dev/vitest/discussions/5710
+		use: any,
+	) => {
+		const registerStaffActionModule = await import("./register-staff-action");
+		await use(registerStaffActionModule.registerStaffAction);
+		vi.clearAllMocks();
+	},
+});
+
+test("名前が空の場合、エラーが表示される", async () => {
+	render(<EditStaffForm />);
+
+	await expect.element(page.getByLabelText("名前")).not.toBeDisabled();
+
+	await page.getByRole("button", { name: "登録する" }).click();
+
+	await expect
+		.element(page.getByText("名前を入力してください"))
+		.toBeInTheDocument();
+});
+
+test("メールアドレスが空の場合、エラーが表示される", async () => {
+	render(<EditStaffForm />);
+
+	await expect.element(page.getByLabelText("名前")).not.toBeDisabled();
+
+	await page.getByLabelText("名前").fill("テスト太郎");
+	await page.getByRole("button", { name: "登録する" }).click();
+
+	await expect
+		.element(
+			page.getByText("メールアドレスを入力してください", { exact: true }),
+		)
+		.toBeInTheDocument();
+});
+
+test("メールアドレスの形式が不正な場合、エラーが表示される", async () => {
+	render(<EditStaffForm />);
+
+	await expect.element(page.getByLabelText("名前")).not.toBeDisabled();
+
+	await page.getByLabelText("名前").fill("テスト太郎");
+	await page.getByLabelText("メールアドレス").fill("invalid-email");
+	await page.getByRole("textbox", { name: "パスワード" }).fill("password123");
+	await page.getByRole("button", { name: "登録する" }).click();
+
+	await expect
+		.element(page.getByText("正しいメールアドレス形式で入力してください"))
+		.toBeInTheDocument();
+});
+
+test("パスワードが空の場合、エラーが表示される", async () => {
+	render(<EditStaffForm />);
+
+	await expect.element(page.getByLabelText("名前")).not.toBeDisabled();
+
+	await page.getByLabelText("名前").fill("テスト太郎");
+	await page.getByLabelText("メールアドレス").fill("test@example.com");
+	await page.getByRole("button", { name: "登録する" }).click();
+
+	await expect
+		.element(page.getByText("パスワードを入力してください"))
+		.toBeInTheDocument();
+});
+
+test("パスワードが8文字未満の場合、エラーが表示される", async () => {
+	render(<EditStaffForm />);
+
+	await expect.element(page.getByLabelText("名前")).not.toBeDisabled();
+
+	await page.getByLabelText("名前").fill("テスト太郎");
+	await page.getByLabelText("メールアドレス").fill("test@example.com");
+	await page.getByRole("textbox", { name: "パスワード" }).fill("1234567");
+	await page.getByRole("button", { name: "登録する" }).click();
+
+	await expect
+		.element(page.getByText("パスワードは8文字以上で入力してください"))
+		.toBeInTheDocument();
+});
+
+test("送信中はボタンが無効化され、ローディング表示になる", async ({
+	registerStaffActionMock,
+}) => {
+	registerStaffActionMock.mockReturnValue(new Promise(() => {}));
+
+	render(<EditStaffForm />);
+
+	await expect.element(page.getByLabelText("名前")).not.toBeDisabled();
+
+	await page.getByLabelText("名前").fill("テスト太郎");
+	await page.getByLabelText("メールアドレス").fill("test@example.com");
+	await page.getByRole("textbox", { name: "パスワード" }).fill("password123");
+	await page.getByRole("button", { name: "登録する" }).click();
+
+	const button = page.getByRole("button", { name: /登録中/ });
+
+	await expect.element(button).toBeDisabled();
+	await expect.element(page.getByText("登録中...")).toBeInTheDocument();
+});
+
+test("登録エラー時にエラーメッセージが表示される", async ({
+	registerStaffActionMock,
+}) => {
+	registerStaffActionMock.mockResolvedValue({
+		error: "このメールアドレスは既に登録されています",
+		success: false,
+	});
+
+	render(<EditStaffForm />);
+
+	await expect.element(page.getByLabelText("名前")).not.toBeDisabled();
+
+	await page.getByLabelText("名前").fill("テスト太郎");
+	await page.getByLabelText("メールアドレス").fill("test@example.com");
+	await page.getByRole("textbox", { name: "パスワード" }).fill("password123");
+	await page.getByRole("button", { name: "登録する" }).click();
+
+	await expect.element(page.getByRole("alert")).toBeInTheDocument();
+	await expect
+		.element(page.getByText("このメールアドレスは既に登録されています"))
+		.toBeInTheDocument();
+});
+
+test("名前が25文字（最大値24文字を超える）場合、エラーが表示される", async () => {
+	render(<EditStaffForm />);
+
+	await expect.element(page.getByLabelText("名前")).not.toBeDisabled();
+
+	await page
+		.getByLabelText("名前")
+		.fill("あいうえおかきくけこさしすせそたちつてとなにぬねのは");
+	await page.getByLabelText("メールアドレス").fill("test@example.com");
+	await page.getByRole("textbox", { name: "パスワード" }).fill("password123");
+	await page.getByRole("button", { name: "登録する" }).click();
+
+	await expect
+		.element(page.getByText("名前は24文字以内で入力してください"))
+		.toBeInTheDocument();
+});
+
+test("メールアドレスが255文字（最大値254文字を超える）場合、エラーが表示される", async () => {
+	render(<EditStaffForm />);
+
+	await expect.element(page.getByLabelText("名前")).not.toBeDisabled();
+
+	const longEmail = `${"a".repeat(64)}@${"example-".repeat(22)}example123.com`;
+	await page.getByLabelText("名前").fill("テスト太郎");
+	await page.getByLabelText("メールアドレス").fill(longEmail);
+	await page.getByRole("textbox", { name: "パスワード" }).fill("password123");
+	await page.getByRole("button", { name: "登録する" }).click();
+
+	await expect
+		.element(page.getByText("メールアドレスは254文字以内で入力してください"))
+		.toBeInTheDocument();
+});
+
+test("パスワードが129文字（最大値128文字を超える）場合、エラーが表示される", async () => {
+	render(<EditStaffForm />);
+
+	await expect.element(page.getByLabelText("名前")).not.toBeDisabled();
+
+	await page.getByLabelText("名前").fill("テスト太郎");
+	await page.getByLabelText("メールアドレス").fill("test@example.com");
+	await page.getByRole("textbox", { name: "パスワード" }).fill("a".repeat(129));
+	await page.getByRole("button", { name: "登録する" }).click();
+
+	await expect
+		.element(page.getByText("パスワードは128文字以内で入力してください"))
+		.toBeInTheDocument();
+});
+
+test("ロールはデフォルトで一般が選択されている", async () => {
+	render(<EditStaffForm />);
+
+	await expect.element(page.getByLabelText("名前")).not.toBeDisabled();
+
+	const userRadio = page.getByRole("radio", { name: "一般" });
+	await expect.element(userRadio).toBeChecked();
+});
+
+test("ロールを管理者に変更できる", async () => {
+	render(<EditStaffForm />);
+
+	await expect.element(page.getByLabelText("名前")).not.toBeDisabled();
+
+	await page.getByRole("radio", { name: "管理者" }).click();
+
+	const adminRadio = page.getByRole("radio", { name: "管理者" });
+	await expect.element(adminRadio).toBeChecked();
+});

--- a/apps/web/features/staff/register/edit-staff-form.tsx
+++ b/apps/web/features/staff/register/edit-staff-form.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import { valibotResolver } from "@hookform/resolvers/valibot";
+import { Button } from "@workspace/ui/components/button";
+import {
+	Form,
+	FormControl,
+	FormDescription,
+	FormField,
+	FormItem,
+	FormLabel,
+	FormMessage,
+} from "@workspace/ui/components/form";
+import { Input } from "@workspace/ui/components/input";
+import { Label } from "@workspace/ui/components/label";
+import {
+	RadioGroup,
+	RadioGroupItem,
+} from "@workspace/ui/components/radio-group";
+import { RequiredBadge } from "@workspace/ui/components/required-badge";
+import { Loader2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { UserRole } from "@/features/auth/user/role";
+import { useIsHydrated } from "@/libs/use-is-hydrated";
+import { registerStaffAction } from "./register-staff-action";
+import { type RegisterStaffParams, registerStaffSchema } from "./schema";
+
+type EditStaffFormProps = {
+	disabled?: boolean;
+};
+
+export function EditStaffForm({ disabled: disabledProp }: EditStaffFormProps) {
+	const router = useRouter();
+	const { isHydrated } = useIsHydrated();
+
+	const form = useForm<RegisterStaffParams>({
+		defaultValues: {
+			email: "",
+			name: "",
+			password: "",
+			role: UserRole.User,
+		},
+		resolver: valibotResolver(registerStaffSchema),
+	});
+
+	async function onSubmit(values: RegisterStaffParams) {
+		form.clearErrors("root");
+
+		const result = await registerStaffAction(values);
+
+		if (result.success) {
+			router.push("/staffs");
+		} else {
+			form.setError("root", {
+				message: result.error || "エラーが発生しました",
+			});
+		}
+	}
+
+	const disabled = !!(
+		form.formState.isSubmitting ||
+		!isHydrated ||
+		disabledProp
+	);
+
+	return (
+		<Form {...form}>
+			<form
+				className="flex flex-col gap-6"
+				noValidate
+				onSubmit={form.handleSubmit(onSubmit)}
+			>
+				<FormField
+					control={form.control}
+					name="name"
+					render={({ field }) => (
+						<FormItem>
+							<FormLabel className="flex items-center gap-2">
+								名前
+								<RequiredBadge />
+							</FormLabel>
+							<FormDescription>24文字以内で入力してください</FormDescription>
+							<FormControl>
+								<Input
+									autoComplete="name"
+									className="max-w-xs"
+									disabled={disabled}
+									type="text"
+									{...field}
+								/>
+							</FormControl>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+
+				<FormField
+					control={form.control}
+					name="email"
+					render={({ field }) => (
+						<FormItem>
+							<FormLabel className="flex items-center gap-2">
+								メールアドレス
+								<RequiredBadge />
+							</FormLabel>
+							<FormDescription>
+								ログインに使用するメールアドレスを入力してください
+							</FormDescription>
+							<FormControl>
+								<Input
+									autoComplete="email"
+									className="max-w-sm"
+									disabled={disabled}
+									type="email"
+									{...field}
+								/>
+							</FormControl>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+
+				<FormField
+					control={form.control}
+					name="password"
+					render={({ field }) => (
+						<FormItem>
+							<FormLabel className="flex items-center gap-2">
+								パスワード
+								<RequiredBadge />
+							</FormLabel>
+							<FormDescription>
+								8文字以上128文字以内で入力してください
+							</FormDescription>
+							<FormControl>
+								<Input
+									autoComplete="new-password"
+									className="max-w-sm"
+									disabled={disabled}
+									type="password"
+									{...field}
+								/>
+							</FormControl>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+
+				<FormField
+					control={form.control}
+					name="role"
+					render={({ field }) => (
+						<FormItem>
+							<FormLabel className="flex items-center gap-2">
+								ロール
+								<RequiredBadge />
+							</FormLabel>
+							<FormDescription>
+								一般は顧客一覧・詳細の表示とノートの一覧・編集・削除が可能。管理者は一般に加えて顧客の登録・編集・削除、スタッフの一覧・登録・編集・削除が可能
+							</FormDescription>
+							<FormControl>
+								<RadioGroup
+									defaultValue={field.value}
+									disabled={disabled}
+									onValueChange={field.onChange}
+								>
+									<div className="flex items-center gap-2">
+										<RadioGroupItem id="role-user" value={UserRole.User} />
+										<Label htmlFor="role-user">一般</Label>
+									</div>
+									<div className="flex items-center gap-2">
+										<RadioGroupItem id="role-admin" value={UserRole.Admin} />
+										<Label htmlFor="role-admin">管理者</Label>
+									</div>
+								</RadioGroup>
+							</FormControl>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+
+				{form.formState.errors.root && (
+					<div className="text-sm text-destructive" role="alert">
+						{form.formState.errors.root.message}
+					</div>
+				)}
+
+				<div className="flex gap-2">
+					<Button
+						disabled={disabled}
+						onClick={() => router.back()}
+						type="button"
+						variant="outline"
+					>
+						キャンセル
+					</Button>
+					<Button className="min-w-[120px]" disabled={disabled} type="submit">
+						{form.formState.isSubmitting ? (
+							<>
+								<Loader2 className="mr-2 size-4 animate-spin" />
+								登録中...
+							</>
+						) : (
+							"登録する"
+						)}
+					</Button>
+				</div>
+			</form>
+		</Form>
+	);
+}

--- a/apps/web/features/staff/register/register-staff-action.small.server.test.ts
+++ b/apps/web/features/staff/register/register-staff-action.small.server.test.ts
@@ -1,0 +1,182 @@
+import { expect, test, vi } from "vitest";
+import { registerStaffAction } from "./register-staff-action";
+
+vi.mock("next/cache", async () => ({
+	updateTag: vi.fn(),
+}));
+
+vi.mock("next/navigation", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("next/navigation")>();
+	return {
+		...actual,
+		redirect: vi.fn(),
+	};
+});
+
+vi.mock("@repo/logger/nextjs/server", () => ({
+	getLogger: vi.fn().mockResolvedValue({
+		error: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+	}),
+}));
+
+vi.mock("@/features/auth/get-user-staff-id", () => ({
+	getUserStaffId: vi.fn().mockResolvedValue("test-staff-id"),
+}));
+
+vi.mock("@/features/auth/get-user-role", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("@/features/auth/get-user-role")>();
+	return {
+		...actual,
+		getUserRole: vi.fn().mockResolvedValue("admin"),
+	};
+});
+
+vi.mock("./register-staff", () => ({
+	registerStaff: vi.fn(),
+}));
+
+test("名前が空の場合にバリデーションエラーを返す", async () => {
+	const { registerStaff } = await import("./register-staff");
+
+	const input = {
+		email: "test@example.com",
+		name: "",
+		password: "password123",
+		role: "user" as const,
+	};
+
+	const result = await registerStaffAction(input);
+
+	expect(result).toBeDefined();
+	expect(result?.success).toBe(false);
+	if (result && !result.success) {
+		expect(result.error).toBe("入力内容に誤りがあります");
+	}
+	expect(registerStaff).not.toHaveBeenCalled();
+});
+
+test("メール形式が不正な場合にバリデーションエラーを返す", async () => {
+	const { registerStaff } = await import("./register-staff");
+
+	const input = {
+		email: "invalid-email",
+		name: "テスト太郎",
+		password: "password123",
+		role: "user" as const,
+	};
+
+	const result = await registerStaffAction(input);
+
+	expect(result).toBeDefined();
+	expect(result?.success).toBe(false);
+	if (result && !result.success) {
+		expect(result.error).toBe("入力内容に誤りがあります");
+	}
+	expect(registerStaff).not.toHaveBeenCalled();
+});
+
+test("パスワードが8文字未満の場合にバリデーションエラーを返す", async () => {
+	const { registerStaff } = await import("./register-staff");
+
+	const input = {
+		email: "test@example.com",
+		name: "テスト太郎",
+		password: "1234567",
+		role: "user" as const,
+	};
+
+	const result = await registerStaffAction(input);
+
+	expect(result).toBeDefined();
+	expect(result?.success).toBe(false);
+	if (result && !result.success) {
+		expect(result.error).toBe("入力内容に誤りがあります");
+	}
+	expect(registerStaff).not.toHaveBeenCalled();
+});
+
+test("name が25文字（境界値超過）の場合にバリデーションエラーを返す", async () => {
+	const { registerStaff } = await import("./register-staff");
+
+	const input = {
+		email: "test@example.com",
+		name: "あ".repeat(25),
+		password: "password123",
+		role: "user" as const,
+	};
+
+	const result = await registerStaffAction(input);
+
+	expect(result).toBeDefined();
+	expect(result?.success).toBe(false);
+	if (result && !result.success) {
+		expect(result.error).toBe("入力内容に誤りがあります");
+	}
+	expect(registerStaff).not.toHaveBeenCalled();
+});
+
+test("email が255文字（境界値超過）の場合にバリデーションエラーを返す", async () => {
+	const { registerStaff } = await import("./register-staff");
+
+	const input = {
+		email: `${"a".repeat(243)}@example.com`,
+		name: "テスト太郎",
+		password: "password123",
+		role: "user" as const,
+	};
+
+	const result = await registerStaffAction(input);
+
+	expect(result).toBeDefined();
+	expect(result?.success).toBe(false);
+	if (result && !result.success) {
+		expect(result.error).toBe("入力内容に誤りがあります");
+	}
+	expect(registerStaff).not.toHaveBeenCalled();
+});
+
+test("password が129文字（境界値超過）の場合にバリデーションエラーを返す", async () => {
+	const { registerStaff } = await import("./register-staff");
+
+	const input = {
+		email: "test@example.com",
+		name: "テスト太郎",
+		password: "a".repeat(129),
+		role: "user" as const,
+	};
+
+	const result = await registerStaffAction(input);
+
+	expect(result).toBeDefined();
+	expect(result?.success).toBe(false);
+	if (result && !result.success) {
+		expect(result.error).toBe("入力内容に誤りがあります");
+	}
+	expect(registerStaff).not.toHaveBeenCalled();
+});
+
+test("登録処理でエラーが発生した場合にエラーメッセージを返す", async () => {
+	const { registerStaff } = await import("./register-staff");
+
+	vi.mocked(registerStaff).mockRejectedValue(new Error("Database error"));
+
+	const input = {
+		email: "test@example.com",
+		name: "テスト太郎",
+		password: "password123",
+		role: "user" as const,
+	};
+
+	const result = await registerStaffAction(input);
+
+	expect(result).toBeDefined();
+	expect(result?.success).toBe(false);
+	if (result && !result.success) {
+		expect(result.error).toBe(
+			"サーバーエラーが発生しました。時間をおいて再度お試しください",
+		);
+	}
+});

--- a/apps/web/features/staff/register/register-staff-action.ts
+++ b/apps/web/features/staff/register/register-staff-action.ts
@@ -1,0 +1,17 @@
+"use server";
+
+import { updateTag } from "next/cache";
+import { UserRole } from "@/features/auth/get-user-role";
+import { createServerAction } from "@/libs/create-server-action";
+import { StaffTag } from "../tag";
+import { registerStaff } from "./register-staff";
+import { registerStaffSchema } from "./schema";
+
+export const registerStaffAction = createServerAction(registerStaff, {
+	name: "registerStaffAction",
+	onSuccess: () => {
+		updateTag(StaffTag.Crud);
+	},
+	role: [UserRole.Admin],
+	schema: registerStaffSchema,
+});

--- a/apps/web/features/staff/register/register-staff.medium.server.test.ts
+++ b/apps/web/features/staff/register/register-staff.medium.server.test.ts
@@ -1,0 +1,137 @@
+import { randomUUID } from "node:crypto";
+import { createAdminClient } from "@repo/supabase/admin";
+import { db } from "@workspace/db/client";
+import { staffsTable } from "@workspace/db/schema/staff";
+import { eq } from "drizzle-orm";
+import { test as base, expect } from "vitest";
+import { registerStaff } from "./register-staff";
+
+const test = base.extend<{
+	cleanup: { emails: string[] };
+}>({
+	cleanup: async (
+		// biome-ignore lint/correctness/noEmptyPattern: Vitestのfixtureパターンで使用する標準的な記法
+		{},
+		use,
+	) => {
+		const emails: string[] = [];
+		await use({ emails });
+
+		const supabase = createAdminClient();
+		for (const email of emails) {
+			await db.delete(staffsTable).where(eq(staffsTable.email, email));
+
+			const { data } = await supabase.auth.admin.listUsers();
+			const user = data.users.find((u) => u.email === email);
+			if (user) {
+				await supabase.auth.admin.deleteUser(user.id);
+			}
+		}
+	},
+});
+
+test("スタッフを正常に登録できる", async ({ cleanup }) => {
+	const uniqueId = randomUUID().slice(0, 8);
+	const input = {
+		email: `staff-${uniqueId}@example.com`,
+		name: `テスト太郎${uniqueId}`,
+		password: "TestPassword123!",
+		role: "user" as const,
+	};
+	cleanup.emails.push(input.email);
+
+	const result = await registerStaff(input);
+
+	expect(result.success).toBe(true);
+	if (result.success) {
+		expect(result.data.staffId).toBeDefined();
+	}
+
+	const staffs = await db
+		.select()
+		.from(staffsTable)
+		.where(eq(staffsTable.email, input.email))
+		.limit(1);
+
+	expect(staffs).toHaveLength(1);
+	expect(staffs[0]?.name).toBe(input.name);
+	expect(staffs[0]?.email).toBe(input.email);
+
+	const supabase = createAdminClient();
+	const { data } = await supabase.auth.admin.listUsers();
+	const user = data.users.find((u) => u.email === input.email);
+	expect(user).toBeDefined();
+	expect(user?.app_metadata?.role).toBe(input.role);
+});
+
+test("name が24文字（境界値）で登録できる", async ({ cleanup }) => {
+	const uniqueId = randomUUID().slice(0, 8);
+	const input = {
+		email: `staff-name24-${uniqueId}@example.com`,
+		name: "あ".repeat(24),
+		password: "TestPassword123!",
+		role: "user" as const,
+	};
+	cleanup.emails.push(input.email);
+
+	const result = await registerStaff(input);
+
+	expect(result.success).toBe(true);
+
+	const staffs = await db
+		.select()
+		.from(staffsTable)
+		.where(eq(staffsTable.email, input.email))
+		.limit(1);
+
+	expect(staffs).toHaveLength(1);
+	expect(staffs[0]?.name).toBe(input.name);
+});
+
+test("管理者ロールで登録できる", async ({ cleanup }) => {
+	const uniqueId = randomUUID().slice(0, 8);
+	const input = {
+		email: `staff-admin-${uniqueId}@example.com`,
+		name: `管理者太郎${uniqueId}`,
+		password: "TestPassword123!",
+		role: "admin" as const,
+	};
+	cleanup.emails.push(input.email);
+
+	const result = await registerStaff(input);
+
+	expect(result.success).toBe(true);
+
+	const supabase = createAdminClient();
+	const { data } = await supabase.auth.admin.listUsers();
+	const user = data.users.find((u) => u.email === input.email);
+	expect(user?.app_metadata?.role).toBe("admin");
+});
+
+test("DBに既に存在するメールアドレスで登録するとエラーになる", async ({
+	cleanup,
+}) => {
+	const uniqueId = randomUUID().slice(0, 8);
+	const email = `staff-dup-${uniqueId}@example.com`;
+	cleanup.emails.push(email);
+
+	await db.insert(staffsTable).values({
+		email,
+		id: randomUUID(),
+		name: `既存スタッフ${uniqueId}`,
+	});
+
+	const input = {
+		email,
+		name: "テスト太郎",
+		password: "TestPassword123!",
+		role: "user" as const,
+	};
+
+	const result = await registerStaff(input);
+
+	expect(result.success).toBe(false);
+	if (!result.success) {
+		expect(result.error).toBe("このメールアドレスは既に登録されています");
+	}
+});

--- a/apps/web/features/staff/register/register-staff.ts
+++ b/apps/web/features/staff/register/register-staff.ts
@@ -1,0 +1,48 @@
+import { fail, type Result, succeed } from "@harusame0616/result";
+import { createAdminClient } from "@repo/supabase/admin";
+import { db } from "@workspace/db/client";
+import { staffsTable } from "@workspace/db/schema/staff";
+import { eq } from "drizzle-orm";
+import { v7 as uuidv7 } from "uuid";
+import type { RegisterStaffParams } from "./schema";
+
+export async function registerStaff({
+	email,
+	name,
+	password,
+	role,
+}: RegisterStaffParams): Promise<Result<{ staffId: string }, string>> {
+	const existingStaff = await db
+		.select({ id: staffsTable.id })
+		.from(staffsTable)
+		.where(eq(staffsTable.email, email))
+		.limit(1);
+
+	if (existingStaff.length > 0) {
+		return fail("このメールアドレスは既に登録されています");
+	}
+
+	const supabase = createAdminClient();
+	const staffId = uuidv7();
+
+	return await db.transaction(async (tx) => {
+		await tx.insert(staffsTable).values({ email, id: staffId, name });
+
+		const { error } = await supabase.auth.admin.createUser({
+			app_metadata: { role, staffId },
+			email,
+			email_confirm: true,
+			password,
+		});
+
+		if (error) {
+			if (error.message.includes("already registered")) {
+				tx.rollback();
+				return fail("このメールアドレスは既に登録されています");
+			}
+			throw error;
+		}
+
+		return succeed({ staffId });
+	});
+}

--- a/apps/web/features/staff/register/schema.ts
+++ b/apps/web/features/staff/register/schema.ts
@@ -1,0 +1,16 @@
+import * as v from "valibot";
+import {
+	staffEmailSchema,
+	staffNameSchema,
+	staffPasswordSchema,
+	staffRoleSchema,
+} from "../schema";
+
+export const registerStaffSchema = v.object({
+	email: staffEmailSchema,
+	name: staffNameSchema,
+	password: staffPasswordSchema,
+	role: staffRoleSchema,
+});
+
+export type RegisterStaffParams = v.InferOutput<typeof registerStaffSchema>;

--- a/apps/web/features/staff/schema.ts
+++ b/apps/web/features/staff/schema.ts
@@ -1,0 +1,27 @@
+import * as v from "valibot";
+import { UserRole } from "@/features/auth/user/role";
+
+export const staffNameSchema = v.pipe(
+	v.string("名前を入力してください"),
+	v.minLength(1, "名前を入力してください"),
+	v.maxLength(24, "名前は24文字以内で入力してください"),
+);
+
+export const staffEmailSchema = v.pipe(
+	v.string("メールアドレスを入力してください"),
+	v.minLength(1, "メールアドレスを入力してください"),
+	v.email("正しいメールアドレス形式で入力してください"),
+	v.maxLength(254, "メールアドレスは254文字以内で入力してください"),
+);
+
+export const staffPasswordSchema = v.pipe(
+	v.string("パスワードを入力してください"),
+	v.minLength(1, "パスワードを入力してください"),
+	v.minLength(8, "パスワードは8文字以上で入力してください"),
+	v.maxLength(128, "パスワードは128文字以内で入力してください"),
+);
+
+export const staffRoleSchema = v.picklist(
+	[UserRole.Admin, UserRole.User],
+	"ロールを選択してください",
+);

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -4,6 +4,7 @@
 		"@radix-ui/react-dialog": "catalog:",
 		"@radix-ui/react-label": "catalog:",
 		"@radix-ui/react-popover": "catalog:",
+		"@radix-ui/react-radio-group": "catalog:",
 		"@radix-ui/react-select": "catalog:",
 		"@radix-ui/react-slot": "catalog:",
 		"@radix-ui/react-switch": "catalog:",

--- a/packages/ui/src/components/radio-group.tsx
+++ b/packages/ui/src/components/radio-group.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
+import { cn } from "@workspace/ui/lib/utils";
+import { CircleIcon } from "lucide-react";
+import type * as React from "react";
+
+function RadioGroup({
+	className,
+	...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Root>) {
+	return (
+		<RadioGroupPrimitive.Root
+			className={cn("grid gap-3", className)}
+			data-slot="radio-group"
+			{...props}
+		/>
+	);
+}
+
+function RadioGroupItem({
+	className,
+	...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Item>) {
+	return (
+		<RadioGroupPrimitive.Item
+			className={cn(
+				"border-input text-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 aspect-square size-4 shrink-0 rounded-full border shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+				className,
+			)}
+			data-slot="radio-group-item"
+			{...props}
+		>
+			<RadioGroupPrimitive.Indicator
+				className="relative flex items-center justify-center"
+				data-slot="radio-group-indicator"
+			>
+				<CircleIcon className="fill-primary absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2" />
+			</RadioGroupPrimitive.Indicator>
+		</RadioGroupPrimitive.Item>
+	);
+}
+
+export { RadioGroup, RadioGroupItem };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ catalogs:
     '@radix-ui/react-popover':
       specifier: ^1.1.15
       version: 1.1.15
+    '@radix-ui/react-radio-group':
+      specifier: ^1.3.8
+      version: 1.3.8
     '@radix-ui/react-select':
       specifier: ^2.2.6
       version: 2.2.6
@@ -347,6 +350,9 @@ importers:
       '@radix-ui/react-popover':
         specifier: 'catalog:'
         version: 1.1.15(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-radio-group':
+        specifier: 'catalog:'
+        version: 1.3.8(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-select':
         specifier: 'catalog:'
         version: 2.2.6(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -1657,6 +1663,19 @@ packages:
 
   '@radix-ui/react-primitive@2.1.4':
     resolution: {integrity: sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-radio-group@1.3.8':
+    resolution: {integrity: sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -5019,6 +5038,24 @@ snapshots:
   '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.2)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.2(@types/react@19.2.2)
+
+  '@radix-ui/react-radio-group@1.3.8(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.2)(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -54,6 +54,7 @@ catalog:
   '@radix-ui/react-collapsible': ^1.1.12
   embla-carousel-react: 8.6.0
   vaul: ^1.1.2
+  '@radix-ui/react-radio-group': ^1.3.8
 
 catalogMode: strict
 


### PR DESCRIPTION
## Summary
- スタッフ登録フォーム（名前、メールアドレス、パスワード、ロール選択）を実装
- スタッフ登録のServer Action（admin権限必須）を追加
- DBとSupabase Authへの同時登録をトランザクションで管理
- メールアドレス重複チェック機能を追加
- スタッフ一覧ページに新規登録リンクを追加（admin専用、Suspense対応）
- テストを追加（ブラウザ、サーバーアクション、Mediumサーバー、E2E）

## 主な変更内容
- `app/(private)/staffs/new/page.tsx` - スタッフ新規登録ページ
- `features/staff/register/` - 登録関連のコンポーネント、スキーマ、アクション
- `features/staff/schema.ts` - スタッフの共通バリデーションスキーマ
- `features/auth/user/role.ts` - クライアントコンポーネント用のロール定義
- `packages/ui/src/components/radio-group.tsx` - RadioGroupコンポーネント追加

## Test plan
- [x] ブラウザテスト（12テスト通過）
- [x] サーバーアクションテスト（7テスト通過）
- [x] Mediumサーバーテスト - registerStaff（4テスト通過）
- [x] E2Eテスト（8テスト通過 - chromium/webkit）

🤖 Generated with [Claude Code](https://claude.com/claude-code)