### PR TITLE
feat: スタッフ削除機能の実装

### DIFF
--- a/apps/web/app/(private)/staffs/[staffId]/@action/default.tsx
+++ b/apps/web/app/(private)/staffs/[staffId]/@action/default.tsx
@@ -1,0 +1,3 @@
+export default function ActionSlotDefault() {
+	return null;
+}

--- a/apps/web/app/(private)/staffs/[staffId]/@action/page.tsx
+++ b/apps/web/app/(private)/staffs/[staffId]/@action/page.tsx
@@ -15,15 +15,15 @@ export default function Page({ params }: PageProps<"/staffs/[staffId]">) {
 }
 
 async function Action({ staffIdPromise }: { staffIdPromise: Promise<string> }) {
-	const staffId = await staffIdPromise;
-	const userRole = await getUserRole();
-	const currentUserStaffId = await getUserStaffId();
-	const isAdmin = userRole === UserRole.Admin;
-	const isSelf = staffId === currentUserStaffId;
+	const [staffId, userRole, currentUserStaffId] = await Promise.all([
+		staffIdPromise,
+		getUserRole(),
+		getUserStaffId(),
+	]);
 
-	return (
-		<div className="flex items-center gap-2">
-			{isAdmin && !isSelf && <DeleteStaffDialog staffId={staffId} />}
-		</div>
-	);
+	if (userRole !== UserRole.Admin || staffId === currentUserStaffId) {
+		return null;
+	}
+
+	return <DeleteStaffDialog staffId={staffId} />;
 }

--- a/apps/web/app/(private)/staffs/[staffId]/@action/page.tsx
+++ b/apps/web/app/(private)/staffs/[staffId]/@action/page.tsx
@@ -1,0 +1,29 @@
+import { Skeleton } from "@workspace/ui/components/skeleton";
+import { Suspense } from "react";
+import { getUserRole, UserRole } from "@/features/auth/get-user-role";
+import { getUserStaffId } from "@/features/auth/get-user-staff-id";
+import { DeleteStaffDialog } from "@/features/staff/delete/delete-staff-dialog";
+
+export default function Page({ params }: PageProps<"/staffs/[staffId]">) {
+	const staffIdPromise = params.then(({ staffId }) => staffId);
+
+	return (
+		<Suspense fallback={<Skeleton className="h-8 w-20 bg-black/10" />}>
+			<Action staffIdPromise={staffIdPromise} />
+		</Suspense>
+	);
+}
+
+async function Action({ staffIdPromise }: { staffIdPromise: Promise<string> }) {
+	const staffId = await staffIdPromise;
+	const userRole = await getUserRole();
+	const currentUserStaffId = await getUserStaffId();
+	const isAdmin = userRole === UserRole.Admin;
+	const isSelf = staffId === currentUserStaffId;
+
+	return (
+		<div className="flex items-center gap-2">
+			{isAdmin && !isSelf && <DeleteStaffDialog staffId={staffId} />}
+		</div>
+	);
+}

--- a/apps/web/app/(private)/staffs/[staffId]/layout.tsx
+++ b/apps/web/app/(private)/staffs/[staffId]/layout.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from "react";
+import { Suspense } from "react";
+import { StaffInfoContainer } from "@/features/staff/detail/staff-info-container";
+import { StaffInfoSkeleton } from "@/features/staff/detail/staff-info-skeleton";
+
+type StaffDetailLayoutProps = LayoutProps<"/staffs/[staffId]"> & {
+	action: ReactNode;
+};
+
+export default async function StaffDetailLayout({
+	params,
+	children,
+	action,
+}: StaffDetailLayoutProps) {
+	const staffIdPromise = params.then(({ staffId }) => staffId);
+
+	return (
+		<div className="container mx-auto p-4 space-y-4">
+			<div className="flex items-center justify-between">
+				<Suspense fallback={<StaffInfoSkeleton />}>
+					<StaffInfoContainer staffIdPromise={staffIdPromise} />
+				</Suspense>
+				{action}
+			</div>
+
+			{children}
+		</div>
+	);
+}

--- a/apps/web/app/(private)/staffs/[staffId]/page.tsx
+++ b/apps/web/app/(private)/staffs/[staffId]/page.tsx
@@ -1,0 +1,16 @@
+import { Card } from "@workspace/ui/components/card";
+import { Suspense } from "react";
+import { StaffBasicInfoContainer } from "@/features/staff/detail/staff-basic-info-container";
+import { StaffBasicInfoSkeleton } from "@/features/staff/detail/staff-basic-info-skeleton";
+
+export default function Page({ params }: PageProps<"/staffs/[staffId]">) {
+	const staffIdPromise = params.then(({ staffId }) => staffId);
+
+	return (
+		<Card className="p-4 w-full">
+			<Suspense fallback={<StaffBasicInfoSkeleton />}>
+				<StaffBasicInfoContainer staffIdPromise={staffIdPromise} />
+			</Suspense>
+		</Card>
+	);
+}

--- a/apps/web/e2e/customer-notes.e2e.test.ts
+++ b/apps/web/e2e/customer-notes.e2e.test.ts
@@ -103,11 +103,11 @@ test("正常系: 4096文字（最大境界値）のノート登録成功", async
 test("正常系: 5枚の画像を含むノート登録成功", async ({ customerNotesPage }) => {
 	const noteContent = `画像5枚のテストノート (${randomUUID()})`;
 	const imagePaths = [
-		path.join(__dirname, "sample1.jpg"),
-		path.join(__dirname, "sample2.jpg"),
-		path.join(__dirname, "sample3.jpg"),
-		path.join(__dirname, "sample4.jpg"),
-		path.join(__dirname, "sample5.jpg"),
+		path.join(import.meta.dirname, "sample1.jpg"),
+		path.join(import.meta.dirname, "sample2.jpg"),
+		path.join(import.meta.dirname, "sample3.jpg"),
+		path.join(import.meta.dirname, "sample4.jpg"),
+		path.join(import.meta.dirname, "sample5.jpg"),
 	];
 
 	await test.step("ノート追加ダイアログを開く", async () => {

--- a/apps/web/e2e/staff-delete.e2e.test.ts
+++ b/apps/web/e2e/staff-delete.e2e.test.ts
@@ -129,22 +129,13 @@ test("一般ユーザーにはスタッフ削除ボタンが表示されない",
 test("管理者でも自分自身の詳細ページでは削除ボタンが表示されない", async ({
 	adminUserPage: page,
 }) => {
-	await test.step("スタッフ一覧ページに遷移", async () => {
-		await page.goto("/staffs");
-		await page.waitForURL("/staffs");
-	});
-
-	await test.step("管理者のメールアドレスで検索", async () => {
-		await page.getByLabel("検索キーワード").fill("admin@example.com");
-		await page.getByRole("button", { name: "検索" }).click();
-	});
-
 	await test.step("自分自身の詳細ページに遷移", async () => {
-		const adminLink = page.getByRole("link", { name: /Admin/i }).first();
-		await adminLink.click();
+		await page.goto("/staffs/00000000-0000-0000-0000-000000000003");
+		await page.waitForURL("/staffs/00000000-0000-0000-0000-000000000003");
 	});
 
 	await test.step("削除ボタンが表示されないことを確認", async () => {
+		await expect(page.getByText("佐藤 次郎")).toBeVisible();
 		await expect(page.getByRole("button", { name: "削除" })).toBeHidden();
 	});
 });

--- a/apps/web/e2e/staff-delete.e2e.test.ts
+++ b/apps/web/e2e/staff-delete.e2e.test.ts
@@ -1,0 +1,149 @@
+import { test as base, expect, type Page } from "@playwright/test";
+import { v4 } from "uuid";
+
+type Fixtures = {
+	adminUserPage: Page;
+	normalUserPage: Page;
+	testStaff: {
+		email: string;
+		name: string;
+		password: string;
+	};
+};
+
+const test = base.extend<Fixtures>({
+	async adminUserPage({ page }, use) {
+		const adminUser = {
+			email: "admin@example.com",
+			password: "Admin@789!",
+		};
+
+		await page.goto("/login");
+		await page.getByLabel("メールアドレス").fill(adminUser.email);
+		await page
+			.getByRole("textbox", { name: "パスワード" })
+			.fill(adminUser.password);
+		await page.getByRole("button", { name: "ログイン" }).click();
+		await page.waitForURL("/");
+
+		await use(page);
+	},
+
+	async normalUserPage({ page }, use) {
+		const testUser = {
+			email: "test1@example.com",
+			password: "Test@Pass123",
+		};
+
+		await page.goto("/login");
+		await page.getByLabel("メールアドレス").fill(testUser.email);
+		await page
+			.getByRole("textbox", { name: "パスワード" })
+			.fill(testUser.password);
+		await page.getByRole("button", { name: "ログイン" }).click();
+		await page.waitForURL("/");
+
+		await use(page);
+	},
+
+	// biome-ignore lint/correctness/noEmptyPattern: Vitestのfixtureパターンで使用する標準的な記法
+	async testStaff({}, use) {
+		const testStaff = {
+			email: `test-staff-${v4()}@example.com`,
+			name: `テスト削除用スタッフ ${v4().slice(0, 8)}`,
+			password: "TestStaff@123",
+		};
+		await use(testStaff);
+	},
+});
+
+test("管理者がスタッフを削除できる", async ({
+	adminUserPage: page,
+	testStaff,
+}) => {
+	let staffId: string;
+
+	await test.step("テスト用スタッフを登録", async () => {
+		await page.goto("/staffs/new");
+		await page.waitForURL("/staffs/new");
+
+		await page.getByLabel("名前").fill(testStaff.name);
+		await page.getByLabel("メールアドレス").fill(testStaff.email);
+		await page.getByLabel("パスワード").fill(testStaff.password);
+		await page.getByLabel("ロール").click();
+		await page.getByRole("option", { name: "一般" }).click();
+
+		await page.getByRole("button", { name: "登録" }).click();
+
+		await page.waitForURL("/staffs");
+	});
+
+	await test.step("スタッフ詳細ページに遷移", async () => {
+		await page.getByLabel("検索キーワード").fill(testStaff.name);
+		await page.getByRole("button", { name: "検索" }).click();
+
+		const staffLink = page.getByRole("link", { name: testStaff.name });
+		await expect(staffLink).toBeVisible();
+
+		const href = await staffLink.getAttribute("href");
+		staffId = href?.replace("/staffs/", "") ?? "";
+
+		await staffLink.click();
+		await page.waitForURL(`/staffs/${staffId}`);
+	});
+
+	await test.step("削除実行", async () => {
+		await page.getByRole("button", { name: "削除" }).click();
+		await page
+			.getByRole("dialog")
+			.getByRole("button", { name: "削除" })
+			.click();
+		await page.waitForURL("/staffs");
+	});
+
+	await test.step("削除されたスタッフを検索してもヒットしないことを確認", async () => {
+		await page.getByLabel("検索キーワード").fill(testStaff.name);
+		await page.getByRole("button", { name: "検索" }).click();
+
+		await expect(
+			page.getByText("スタッフが見つかりませんでした"),
+		).toBeVisible();
+	});
+});
+
+test("一般ユーザーにはスタッフ削除ボタンが表示されない", async ({
+	normalUserPage: page,
+}) => {
+	await test.step("スタッフ詳細ページに遷移", async () => {
+		await page.goto("/staffs/00000000-0000-0000-0000-000000000001");
+		await page.waitForURL("/staffs/00000000-0000-0000-0000-000000000001");
+	});
+
+	await test.step("削除ボタンが表示されないことを確認", async () => {
+		await expect(page.getByText("田中 太郎")).toBeVisible();
+		await expect(page.getByRole("button", { name: "削除" })).toBeHidden();
+	});
+});
+
+test("管理者でも自分自身の詳細ページでは削除ボタンが表示されない", async ({
+	adminUserPage: page,
+}) => {
+	await test.step("スタッフ一覧ページに遷移", async () => {
+		await page.goto("/staffs");
+		await page.waitForURL("/staffs");
+	});
+
+	await test.step("管理者のメールアドレスで検索", async () => {
+		await page.getByLabel("検索キーワード").fill("admin@example.com");
+		await page.getByRole("button", { name: "検索" }).click();
+	});
+
+	await test.step("自分自身の詳細ページに遷移", async () => {
+		const adminLink = page.getByRole("link", { name: /Admin/i }).first();
+		await adminLink.click();
+	});
+
+	await test.step("削除ボタンが表示されないことを確認", async () => {
+		await expect(page.getByRole("button", { name: "削除" })).toBeHidden();
+	});
+});

--- a/apps/web/e2e/staff-delete.e2e.test.ts
+++ b/apps/web/e2e/staff-delete.e2e.test.ts
@@ -69,9 +69,10 @@ test("管理者がスタッフを削除できる", async ({
 
 		await page.getByLabel("名前").fill(testStaff.name);
 		await page.getByLabel("メールアドレス").fill(testStaff.email);
-		await page.getByLabel("パスワード").fill(testStaff.password);
-		await page.getByLabel("ロール").click();
-		await page.getByRole("option", { name: "一般" }).click();
+		await page
+			.getByRole("textbox", { name: "パスワード" })
+			.fill(testStaff.password);
+		await page.getByRole("radio", { name: "一般" }).click();
 
 		await page.getByRole("button", { name: "登録" }).click();
 

--- a/apps/web/features/customer-note/list/get-customer-notes.ts
+++ b/apps/web/features/customer-note/list/get-customer-notes.ts
@@ -21,6 +21,7 @@ import {
 } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
 import { CustomerTag } from "@/features/customer/tag";
+import { StaffTag } from "@/features/staff/tag";
 import { getCustomerNoteImageUrl } from "./get-customer-note-image-url";
 
 export type CustomerNoteSearchCondition = {
@@ -61,7 +62,7 @@ export async function getCustomerNotes(
 	currentPage: number;
 	totalPages: number;
 }> {
-	cacheTag(CustomerTag.NoteCrud(condition.customerId));
+	cacheTag(CustomerTag.NoteCrud(condition.customerId), StaffTag.Delete);
 	cacheLife("permanent");
 
 	const page = condition.page ?? 1;

--- a/apps/web/features/customer/delete/delete-customer-dialog.tsx
+++ b/apps/web/features/customer/delete/delete-customer-dialog.tsx
@@ -11,7 +11,6 @@ import {
 	DialogTrigger,
 } from "@workspace/ui/components/dialog";
 import { AlertCircle, Loader2, Trash2 } from "lucide-react";
-import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
 import { deleteCustomerAction } from "./delete-customer-action";
 
@@ -22,7 +21,6 @@ type DeleteCustomerDialogProps = {
 export function DeleteCustomerDialog({
 	customerId,
 }: DeleteCustomerDialogProps) {
-	const _router = useRouter();
 	const [open, setOpen] = useState(false);
 	const [isPending, startTransition] = useTransition();
 	const [errorMessage, setErrorMessage] = useState<string | null>(null);

--- a/apps/web/features/staff/delete/delete-staff-action.small.server.test.ts
+++ b/apps/web/features/staff/delete/delete-staff-action.small.server.test.ts
@@ -1,0 +1,99 @@
+import { test as base, expect, type Mock, vi } from "vitest";
+import { deleteStaffAction } from "./delete-staff-action";
+
+vi.mock("@repo/logger/nextjs/server", () => ({
+	getLogger: vi.fn().mockResolvedValue({
+		info: vi.fn(),
+		warn: vi.fn(),
+	}),
+}));
+
+vi.mock("@/features/auth/get-user-staff-id", () => ({
+	getUserStaffId: vi.fn(),
+}));
+
+vi.mock("@/features/auth/get-user-role", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("@/features/auth/get-user-role")>();
+	return {
+		...actual,
+		getUserRole: vi.fn(),
+	};
+});
+
+const test = base.extend<{
+	getUserStaffIdMock: Mock;
+	getUserRoleMock: Mock;
+}>({
+	// biome-ignore lint/correctness/noEmptyPattern: Vitestのfixtureパターンで使用する標準的な記法
+	// biome-ignore lint/suspicious/noExplicitAny: https://github.com/vitest-dev/vitest/discussions/5710
+	getUserRoleMock: async ({}, use: any) => {
+		const getUserRoleModule = await import("@/features/auth/get-user-role");
+		const mock = vi.mocked(getUserRoleModule.getUserRole);
+		await use(mock);
+		vi.clearAllMocks();
+	},
+	// biome-ignore lint/correctness/noEmptyPattern: Vitestのfixtureパターンで使用する標準的な記法
+	// biome-ignore lint/suspicious/noExplicitAny: https://github.com/vitest-dev/vitest/discussions/5710
+	getUserStaffIdMock: async ({}, use: any) => {
+		const getUserStaffIdModule = await import(
+			"@/features/auth/get-user-staff-id"
+		);
+		const mock = vi.mocked(getUserStaffIdModule.getUserStaffId);
+		await use(mock);
+		vi.clearAllMocks();
+	},
+});
+
+test("一般ユーザーロールの場合、権限エラーが返される", async ({
+	getUserStaffIdMock,
+	getUserRoleMock,
+}) => {
+	const testStaffId = "00000000-0000-0000-0000-000000000001";
+
+	getUserStaffIdMock.mockResolvedValue("staff-id");
+	getUserRoleMock.mockResolvedValue("user");
+
+	const result = await deleteStaffAction({
+		staffId: testStaffId,
+	});
+
+	expect(result.success).toBe(false);
+	if (!result.success) {
+		expect(result.error).toBe("この操作を実行する権限がありません");
+	}
+});
+
+test("認証されていない場合、認証エラーが返される", async ({
+	getUserStaffIdMock,
+}) => {
+	const testStaffId = "00000000-0000-0000-0000-000000000001";
+
+	getUserStaffIdMock.mockResolvedValue(null);
+
+	const result = await deleteStaffAction({
+		staffId: testStaffId,
+	});
+
+	expect(result.success).toBe(false);
+	if (!result.success) {
+		expect(result.error).toBe("認証に失敗しました");
+	}
+});
+
+test("不正なstaffIdの場合、バリデーションエラーが返される", async ({
+	getUserStaffIdMock,
+	getUserRoleMock,
+}) => {
+	getUserStaffIdMock.mockResolvedValue("staff-id");
+	getUserRoleMock.mockResolvedValue("admin");
+
+	const result = await deleteStaffAction({
+		staffId: "invalid-uuid",
+	});
+
+	expect(result.success).toBe(false);
+	if (!result.success) {
+		expect(result.error).toBe("入力内容に誤りがあります");
+	}
+});

--- a/apps/web/features/staff/delete/delete-staff-action.ts
+++ b/apps/web/features/staff/delete/delete-staff-action.ts
@@ -1,0 +1,38 @@
+"use server";
+
+import { fail, type Result } from "@harusame0616/result";
+import { updateTag } from "next/cache";
+import { RedirectType, redirect } from "next/navigation";
+import * as v from "valibot";
+import { UserRole } from "@/features/auth/get-user-role";
+import { getUserStaffId } from "@/features/auth/get-user-staff-id";
+import { StaffTag } from "@/features/staff/tag";
+import { createServerAction } from "@/libs/create-server-action";
+import { deleteStaff } from "./delete-staff";
+
+const deleteStaffSchema = v.object({
+	staffId: v.pipe(v.string(), v.uuid()),
+});
+
+async function deleteStaffWithContext(input: {
+	staffId: string;
+}): Promise<Result<undefined, string>> {
+	const currentUserStaffId = await getUserStaffId();
+
+	if (!currentUserStaffId) {
+		return fail("認証に失敗しました");
+	}
+
+	return deleteStaff({ currentUserStaffId, staffId: input.staffId });
+}
+
+export const deleteStaffAction = createServerAction(deleteStaffWithContext, {
+	name: "deleteStaffAction",
+	onSuccess: () => {
+		updateTag(StaffTag.Crud);
+		updateTag(StaffTag.Delete);
+		redirect("/staffs", RedirectType.replace);
+	},
+	role: [UserRole.Admin],
+	schema: deleteStaffSchema,
+});

--- a/apps/web/features/staff/delete/delete-staff-dialog.browser.test.tsx
+++ b/apps/web/features/staff/delete/delete-staff-dialog.browser.test.tsx
@@ -1,0 +1,40 @@
+import { expect, test, vi } from "vitest";
+import { page } from "vitest/browser";
+import { render } from "vitest-browser-react";
+import { DeleteStaffDialog } from "./delete-staff-dialog";
+
+vi.mock("./delete-staff-action", () => ({
+	deleteStaffAction: vi.fn(),
+}));
+
+test("削除ボタンをクリックするとダイアログが表示される", async () => {
+	render(<DeleteStaffDialog staffId="test-id" />);
+
+	await page.getByRole("button", { name: "削除" }).click();
+
+	const dialog = page.getByRole("dialog");
+	await expect.element(dialog).toBeInTheDocument();
+	await expect
+		.element(dialog.getByRole("heading", { name: "スタッフを削除" }))
+		.toBeInTheDocument();
+	await expect
+		.element(
+			dialog.getByText(
+				"このスタッフを削除してもよろしいですか？この操作は取り消せません。",
+			),
+		)
+		.toBeInTheDocument();
+});
+
+test("キャンセルボタンをクリックするとダイアログが閉じる", async () => {
+	render(<DeleteStaffDialog staffId="test-id" />);
+
+	await page.getByRole("button", { name: "削除" }).click();
+
+	const dialog = page.getByRole("dialog");
+	await expect.element(dialog).toBeInTheDocument();
+
+	await dialog.getByRole("button", { name: "キャンセル" }).click();
+
+	await expect.element(dialog).not.toBeInTheDocument();
+});

--- a/apps/web/features/staff/delete/delete-staff-dialog.tsx
+++ b/apps/web/features/staff/delete/delete-staff-dialog.tsx
@@ -11,7 +11,6 @@ import {
 	DialogTrigger,
 } from "@workspace/ui/components/dialog";
 import { AlertCircle, Loader2, Trash2 } from "lucide-react";
-import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
 import { deleteStaffAction } from "./delete-staff-action";
 
@@ -20,7 +19,6 @@ type DeleteStaffDialogProps = {
 };
 
 export function DeleteStaffDialog({ staffId }: DeleteStaffDialogProps) {
-	const _router = useRouter();
 	const [open, setOpen] = useState(false);
 	const [isPending, startTransition] = useTransition();
 	const [errorMessage, setErrorMessage] = useState<string | null>(null);

--- a/apps/web/features/staff/delete/delete-staff-dialog.tsx
+++ b/apps/web/features/staff/delete/delete-staff-dialog.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { Button } from "@workspace/ui/components/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@workspace/ui/components/dialog";
+import { AlertCircle, Loader2, Trash2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import { deleteStaffAction } from "./delete-staff-action";
+
+type DeleteStaffDialogProps = {
+	staffId: string;
+};
+
+export function DeleteStaffDialog({ staffId }: DeleteStaffDialogProps) {
+	const _router = useRouter();
+	const [open, setOpen] = useState(false);
+	const [isPending, startTransition] = useTransition();
+	const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+	function handleDelete() {
+		setErrorMessage(null);
+
+		startTransition(async () => {
+			const result = await deleteStaffAction({ staffId });
+
+			if (!result.success) {
+				setErrorMessage(result.error);
+				return;
+			}
+
+			setErrorMessage(null);
+		});
+	}
+
+	function handleOpenChange(open: boolean) {
+		if (!open) {
+			setErrorMessage(null);
+		}
+		setOpen(open);
+	}
+
+	return (
+		<Dialog onOpenChange={handleOpenChange} open={open}>
+			<DialogTrigger asChild>
+				<Button size="sm" type="button" variant="destructive">
+					<Trash2 className="h-4 w-4 mr-1" />
+					削除
+				</Button>
+			</DialogTrigger>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>スタッフを削除</DialogTitle>
+					<DialogDescription asChild>
+						<div className="space-y-2">
+							<p>
+								このスタッフを削除してもよろしいですか？この操作は取り消せません。
+							</p>
+							<p>
+								スタッフに紐づくデータ（作成した顧客ノートなど）も削除されます。
+							</p>
+							<p>
+								退職などの場合は、削除ではなくスタッフの無効化を推奨します。
+							</p>
+						</div>
+					</DialogDescription>
+				</DialogHeader>
+
+				{errorMessage && (
+					<div className="bg-destructive/10 text-destructive flex items-center gap-2 rounded-md p-3 text-sm">
+						<AlertCircle className="h-4 w-4 shrink-0" />
+						<p>{errorMessage}</p>
+					</div>
+				)}
+
+				<DialogFooter>
+					<Button
+						disabled={isPending}
+						onClick={() => handleOpenChange(false)}
+						type="button"
+						variant="outline"
+					>
+						キャンセル
+					</Button>
+					<Button
+						className="min-w-[120px]"
+						disabled={isPending}
+						onClick={handleDelete}
+						type="button"
+						variant="destructive"
+					>
+						{isPending ? (
+							<>
+								削除中
+								<Loader2 className="ml-2 size-4 animate-spin" />
+							</>
+						) : (
+							"削除"
+						)}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/web/features/staff/delete/delete-staff.medium.server.test.ts
+++ b/apps/web/features/staff/delete/delete-staff.medium.server.test.ts
@@ -1,0 +1,144 @@
+import { db } from "@workspace/db/client";
+import { staffsTable } from "@workspace/db/schema/staff";
+import { eq } from "drizzle-orm";
+import { v4 } from "uuid";
+import { test as base, expect, type Mock, vi } from "vitest";
+import { deleteStaff } from "./delete-staff";
+
+vi.mock("@repo/logger/nextjs/server", () => ({
+	getLogger: vi.fn().mockResolvedValue({
+		error: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+	}),
+}));
+
+vi.mock("@repo/supabase/admin", () => ({
+	createAdminClient: vi.fn(),
+}));
+
+const test = base.extend<{
+	staff: {
+		email: string;
+		id: string;
+		name: string;
+	};
+	supabaseAdminMock: Mock;
+}>({
+	// biome-ignore lint/correctness/noEmptyPattern: Vitestのfixtureパターンで使用する標準的な記法
+	async staff({}, use) {
+		const staff = {
+			email: `${v4()}@example.com`,
+			id: v4(),
+			name: v4().slice(0, 24),
+		};
+
+		await db.insert(staffsTable).values(staff);
+		await use(staff);
+		await db.delete(staffsTable).where(eq(staffsTable.id, staff.id));
+	},
+	// biome-ignore lint/correctness/noEmptyPattern: Vitestのfixtureパターンで使用する標準的な記法
+	// biome-ignore lint/suspicious/noExplicitAny: https://github.com/vitest-dev/vitest/discussions/5710
+	async supabaseAdminMock({}, use: any) {
+		const supabaseModule = await import("@repo/supabase/admin");
+		const mock = vi.mocked(supabaseModule.createAdminClient);
+		await use(mock);
+		vi.clearAllMocks();
+	},
+});
+
+test("存在しないスタッフを削除しようとした場合にエラーが返される", async () => {
+	const nonExistentStaffId = "99999999-9999-9999-9999-999999999999";
+	const currentUserStaffId = "00000000-0000-0000-0000-000000000001";
+
+	const result = await deleteStaff({
+		currentUserStaffId,
+		staffId: nonExistentStaffId,
+	});
+
+	expect(result.success).toBe(false);
+	if (!result.success) {
+		expect(result.error).toBe("指定されたスタッフが見つかりません");
+	}
+});
+
+test("自分自身を削除しようとした場合にエラーが返される", async ({ staff }) => {
+	const result = await deleteStaff({
+		currentUserStaffId: staff.id,
+		staffId: staff.id,
+	});
+
+	expect(result.success).toBe(false);
+	if (!result.success) {
+		expect(result.error).toBe("自分自身は削除できません");
+	}
+});
+
+test("存在するスタッフを削除できる", async ({ staff, supabaseAdminMock }) => {
+	const currentUserStaffId = "00000000-0000-0000-0000-000000000001";
+	const authUserId = "auth-user-id";
+
+	supabaseAdminMock.mockReturnValue({
+		auth: {
+			admin: {
+				deleteUser: vi.fn().mockResolvedValue({ error: null }),
+				listUsers: vi.fn().mockResolvedValue({
+					data: {
+						users: [
+							{
+								app_metadata: { staffId: staff.id },
+								id: authUserId,
+							},
+						],
+					},
+					error: null,
+				}),
+			},
+		},
+	});
+
+	const result = await deleteStaff({
+		currentUserStaffId,
+		staffId: staff.id,
+	});
+
+	expect(result.success).toBe(true);
+
+	const [deletedStaff] = await db
+		.select()
+		.from(staffsTable)
+		.where(eq(staffsTable.id, staff.id))
+		.limit(1);
+
+	expect(deletedStaff).toBeUndefined();
+});
+
+test("Auth ユーザーが見つからない場合にエラーが返される", async ({
+	staff,
+	supabaseAdminMock,
+}) => {
+	const currentUserStaffId = "00000000-0000-0000-0000-000000000001";
+
+	supabaseAdminMock.mockReturnValue({
+		auth: {
+			admin: {
+				listUsers: vi.fn().mockResolvedValue({
+					data: {
+						users: [],
+					},
+					error: null,
+				}),
+			},
+		},
+	});
+
+	const result = await deleteStaff({
+		currentUserStaffId,
+		staffId: staff.id,
+	});
+
+	expect(result.success).toBe(false);
+	if (!result.success) {
+		expect(result.error).toBe("認証ユーザーが見つかりません");
+	}
+});

--- a/apps/web/features/staff/delete/delete-staff.ts
+++ b/apps/web/features/staff/delete/delete-staff.ts
@@ -1,0 +1,88 @@
+import { fail, type Result, succeed } from "@harusame0616/result";
+import { getLogger } from "@repo/logger/nextjs/server";
+import { createAdminClient } from "@repo/supabase/admin";
+import { db } from "@workspace/db/client";
+import { staffsTable } from "@workspace/db/schema/staff";
+import { eq } from "drizzle-orm";
+
+const STAFF_NOT_FOUND_ERROR_MESSAGE =
+	"指定されたスタッフが見つかりません" as const;
+const CANNOT_DELETE_SELF_ERROR_MESSAGE = "自分自身は削除できません" as const;
+const AUTH_USER_NOT_FOUND_ERROR_MESSAGE =
+	"認証ユーザーが見つかりません" as const;
+
+type DeleteStaffErrorMessage =
+	| typeof STAFF_NOT_FOUND_ERROR_MESSAGE
+	| typeof CANNOT_DELETE_SELF_ERROR_MESSAGE
+	| typeof AUTH_USER_NOT_FOUND_ERROR_MESSAGE;
+
+type DeleteStaffInput = {
+	currentUserStaffId: string;
+	staffId: string;
+};
+
+export async function deleteStaff({
+	currentUserStaffId,
+	staffId,
+}: DeleteStaffInput): Promise<Result<undefined, DeleteStaffErrorMessage>> {
+	const logger = await getLogger("deleteStaff");
+
+	if (staffId === currentUserStaffId) {
+		logger.warn("自分自身を削除しようとしました", { staffId });
+		return fail(CANNOT_DELETE_SELF_ERROR_MESSAGE);
+	}
+
+	const [staff] = await db
+		.select()
+		.from(staffsTable)
+		.where(eq(staffsTable.id, staffId))
+		.limit(1);
+
+	if (!staff) {
+		logger.warn("スタッフが見つかりません", { staffId });
+		return fail(STAFF_NOT_FOUND_ERROR_MESSAGE);
+	}
+
+	const supabase = createAdminClient();
+
+	const { data: usersData, error: listError } =
+		await supabase.auth.admin.listUsers();
+
+	if (listError) {
+		logger.error("Auth ユーザー一覧の取得に失敗", { err: listError });
+		throw listError;
+	}
+
+	const authUser = usersData.users.find(
+		// biome-ignore lint: ts4111
+		(user) => user.app_metadata?.["staffId"] === staffId,
+	);
+
+	if (!authUser) {
+		logger.warn("Auth ユーザーが見つかりません", { staffId });
+		return fail(AUTH_USER_NOT_FOUND_ERROR_MESSAGE);
+	}
+
+	await db.transaction(async (tx) => {
+		await tx.delete(staffsTable).where(eq(staffsTable.id, staffId));
+
+		const { error: deleteError } = await supabase.auth.admin.deleteUser(
+			authUser.id,
+		);
+
+		if (deleteError) {
+			logger.error("Auth ユーザーの削除に失敗", {
+				err: deleteError,
+				staffId,
+			});
+			throw deleteError;
+		}
+	});
+
+	logger.info("スタッフの削除に成功", {
+		action: "delete-staff",
+		staffId,
+	});
+
+	return succeed();
+}

--- a/apps/web/features/staff/detail/get-staff-detail.ts
+++ b/apps/web/features/staff/detail/get-staff-detail.ts
@@ -1,0 +1,20 @@
+import { db } from "@workspace/db/client";
+import { staffsTable } from "@workspace/db/schema/staff";
+import { eq } from "drizzle-orm";
+import { cacheLife, cacheTag } from "next/cache";
+import { cache } from "react";
+import { StaffTag } from "../tag";
+
+export const getStaffDetail = cache(async (staffId: string) => {
+	"use cache";
+	cacheLife("permanent");
+	cacheTag(StaffTag.Crud);
+
+	const staffs = await db
+		.select()
+		.from(staffsTable)
+		.where(eq(staffsTable.id, staffId))
+		.limit(1);
+
+	return staffs[0] ?? null;
+});

--- a/apps/web/features/staff/detail/staff-basic-info-container.tsx
+++ b/apps/web/features/staff/detail/staff-basic-info-container.tsx
@@ -1,0 +1,20 @@
+import { notFound } from "next/navigation";
+import { getStaffDetail } from "./get-staff-detail";
+import { StaffBasicInfoPresenter } from "./staff-basic-info-presenter";
+
+type StaffBasicInfoContainerProps = {
+	staffIdPromise: Promise<string>;
+};
+
+export async function StaffBasicInfoContainer({
+	staffIdPromise,
+}: StaffBasicInfoContainerProps) {
+	const staffId = await staffIdPromise;
+	const staff = await getStaffDetail(staffId);
+
+	if (!staff) {
+		notFound();
+	}
+
+	return <StaffBasicInfoPresenter staff={staff} />;
+}

--- a/apps/web/features/staff/detail/staff-basic-info-presenter.tsx
+++ b/apps/web/features/staff/detail/staff-basic-info-presenter.tsx
@@ -1,0 +1,53 @@
+import type { ReactNode } from "react";
+import { DateTime } from "@/components/date-time";
+
+type Staff = {
+	createdAt: Date;
+	email: string;
+	id: string;
+	name: string;
+	updatedAt: Date;
+};
+
+type StaffBasicInfoPresenterProps = {
+	staff: Staff;
+};
+
+type StaffField = {
+	label: string;
+	value: ReactNode;
+};
+
+export function StaffBasicInfoPresenter({
+	staff,
+}: StaffBasicInfoPresenterProps) {
+	const fields: StaffField[] = [
+		{
+			label: "メールアドレス",
+			value: (
+				<a className="text-primary underline" href={`mailto:${staff.email}`}>
+					{staff.email}
+				</a>
+			),
+		},
+		{
+			label: "登録日",
+			value: <DateTime date={staff.createdAt} />,
+		},
+		{
+			label: "更新日",
+			value: <DateTime date={staff.updatedAt} />,
+		},
+	];
+
+	return (
+		<div className="space-y-4">
+			{fields.map((field) => (
+				<div className="grid gap-2" key={field.label}>
+					<div className="text-sm text-muted-foreground">{field.label}</div>
+					<div className="font-bold">{field.value}</div>
+				</div>
+			))}
+		</div>
+	);
+}

--- a/apps/web/features/staff/detail/staff-basic-info-skeleton.tsx
+++ b/apps/web/features/staff/detail/staff-basic-info-skeleton.tsx
@@ -1,0 +1,20 @@
+import { Skeleton } from "@workspace/ui/components/skeleton";
+
+export function StaffBasicInfoSkeleton() {
+	return (
+		<div className="space-y-4">
+			<div className="grid gap-2">
+				<Skeleton className="text-sm text-muted-foreground h-[1.25rem] w-28" />
+				<Skeleton className="font-bold h-[1.5rem] w-48" />
+			</div>
+			<div className="grid gap-2">
+				<Skeleton className="text-sm text-muted-foreground h-[1.25rem] w-12" />
+				<Skeleton className="font-bold h-[1.5rem] w-40" />
+			</div>
+			<div className="grid gap-2">
+				<Skeleton className="text-sm text-muted-foreground h-[1.25rem] w-12" />
+				<Skeleton className="font-bold h-[1.5rem] w-40" />
+			</div>
+		</div>
+	);
+}

--- a/apps/web/features/staff/detail/staff-info-container.tsx
+++ b/apps/web/features/staff/detail/staff-info-container.tsx
@@ -1,0 +1,19 @@
+import { notFound } from "next/navigation";
+import { getStaffDetail } from "./get-staff-detail";
+import { StaffInfoPresenter } from "./staff-info-presenter";
+
+type StaffInfoContainerProps = {
+	staffIdPromise: Promise<string>;
+};
+
+export async function StaffInfoContainer({
+	staffIdPromise,
+}: StaffInfoContainerProps) {
+	const staff = await getStaffDetail(await staffIdPromise);
+
+	if (!staff) {
+		notFound();
+	}
+
+	return <StaffInfoPresenter name={staff.name} />;
+}

--- a/apps/web/features/staff/detail/staff-info-presenter.tsx
+++ b/apps/web/features/staff/detail/staff-info-presenter.tsx
@@ -1,0 +1,7 @@
+type StaffInfoPresenterProps = {
+	name: string;
+};
+
+export function StaffInfoPresenter({ name }: StaffInfoPresenterProps) {
+	return <h1 className="text-2xl font-bold h-9">{name}</h1>;
+}

--- a/apps/web/features/staff/detail/staff-info-skeleton.tsx
+++ b/apps/web/features/staff/detail/staff-info-skeleton.tsx
@@ -1,0 +1,5 @@
+import { Skeleton } from "@workspace/ui/components/skeleton";
+
+export function StaffInfoSkeleton() {
+	return <Skeleton className="text-2xl font-bold h-9 w-48 bg-black/10" />;
+}

--- a/apps/web/features/staff/list/staffs-presenter.tsx
+++ b/apps/web/features/staff/list/staffs-presenter.tsx
@@ -7,6 +7,7 @@ import {
 	TableHeader,
 	TableRow,
 } from "@workspace/ui/components/table";
+import Link from "next/link";
 import type { StaffsListItem } from "./schema";
 
 type StaffsPresenterProps = {
@@ -42,7 +43,14 @@ export function StaffsPresenter({
 				<TableBody>
 					{staffs.map((staff) => (
 						<TableRow key={staff.id}>
-							<TableCell>{staff.name}</TableCell>
+							<TableCell>
+								<Link
+									className="text-primary underline"
+									href={`/staffs/${staff.id}`}
+								>
+									{staff.name}
+								</Link>
+							</TableCell>
 							<TableCell>{staff.email}</TableCell>
 						</TableRow>
 					))}

--- a/apps/web/features/staff/tag.ts
+++ b/apps/web/features/staff/tag.ts
@@ -1,3 +1,4 @@
 export const StaffTag = {
 	Crud: "STAFF_TAG_CRUD",
+	Delete: "STAFF_TAG_DELETE",
 };

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -47,5 +47,6 @@
 		"test:server": "vitest --run --project server",
 		"type:check": "echo 'nextjs で tsc でのタイプチェックは非推奨のため未実施。 （build 時に型チェック）'"
 	},
+	"type": "module",
 	"version": "0.1.0"
 }

--- a/packages/supabase/package.json
+++ b/packages/supabase/package.json
@@ -26,5 +26,6 @@
 		"supabase:start": "supabase start",
 		"type:check": "tsc --noEmit"
 	},
+	"type": "module",
 	"version": "0.0.0"
 }


### PR DESCRIPTION
## Summary
- スタッフ詳細ページを新規作成（/staffs/[staffId]）
- スタッフ削除機能を実装（管理者のみ、自分自身は削除不可）
- DB削除とAuth削除をトランザクションで管理し、Auth削除失敗時はロールバック
- スタッフ削除時に顧客ノートのキャッシュも無効化（StaffTag.Delete）
- 削除ダイアログに関連データ削除と無効化推奨の説明を追加

## Test plan
- [ ] Small テスト（delete-staff-action.small.server.test.ts）がパスすること
- [ ] Medium テスト（delete-staff.medium.server.test.ts）がパスすること
- [ ] Browser テスト（delete-staff-dialog.browser.test.tsx）がパスすること
- [ ] E2E テスト（staff-delete.e2e.test.ts）がパスすること
- [ ] 管理者でスタッフ詳細ページにアクセスし、削除ボタンが表示されること
- [ ] 一般ユーザーでスタッフ詳細ページにアクセスし、削除ボタンが表示されないこと
- [ ] 自分自身の詳細ページでは削除ボタンが表示されないこと
- [ ] スタッフ削除後、Auth ユーザーも削除されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)