### PR TITLE
refactor: staffsTableからemail列を削除しauth.usersから取得するよう変更

### DIFF
--- a/apps/web/features/staff/detail/get-staff-detail.ts
+++ b/apps/web/features/staff/detail/get-staff-detail.ts
@@ -1,8 +1,10 @@
 import { db } from "@workspace/db/client";
 import { staffsTable } from "@workspace/db/schema/staff";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
+import { authUsers } from "drizzle-orm/supabase";
 import { cacheLife, cacheTag } from "next/cache";
 import { cache } from "react";
+import { UserRole } from "../../auth/user/role";
 import { StaffTag } from "../tag";
 
 export const getStaffDetail = cache(async (staffId: string) => {
@@ -11,8 +13,17 @@ export const getStaffDetail = cache(async (staffId: string) => {
 	cacheTag(StaffTag.Crud);
 
 	const staffs = await db
-		.select()
+		.select({
+			authUserId: staffsTable.authUserId,
+			createdAt: staffsTable.createdAt,
+			email: sql<string>`COALESCE(${authUsers.email}, '')`,
+			id: staffsTable.id,
+			name: staffsTable.name,
+			role: sql<string>`COALESCE("auth"."users".raw_app_meta_data->>'role', ${UserRole.Admin})`,
+			updatedAt: staffsTable.updatedAt,
+		})
 		.from(staffsTable)
+		.leftJoin(authUsers, eq(staffsTable.authUserId, authUsers.id))
 		.where(eq(staffsTable.id, staffId))
 		.limit(1);
 

--- a/apps/web/features/staff/detail/staff-basic-info-presenter.tsx
+++ b/apps/web/features/staff/detail/staff-basic-info-presenter.tsx
@@ -6,8 +6,14 @@ type Staff = {
 	email: string;
 	id: string;
 	name: string;
+	role: string;
 	updatedAt: Date;
 };
+
+const RoleLabel = {
+	admin: "管理者",
+	user: "一般",
+} as const;
 
 type StaffBasicInfoPresenterProps = {
 	staff: Staff;
@@ -21,14 +27,19 @@ type StaffField = {
 export function StaffBasicInfoPresenter({
 	staff,
 }: StaffBasicInfoPresenterProps) {
+	const roleLabel =
+		staff.role in RoleLabel
+			? RoleLabel[staff.role as keyof typeof RoleLabel]
+			: staff.role;
+
 	const fields: StaffField[] = [
 		{
 			label: "メールアドレス",
-			value: (
-				<a className="text-primary underline" href={`mailto:${staff.email}`}>
-					{staff.email}
-				</a>
-			),
+			value: staff.email || "-",
+		},
+		{
+			label: "ロール",
+			value: roleLabel,
 		},
 		{
 			label: "登録日",

--- a/apps/web/features/staff/list/get-staffs.ts
+++ b/apps/web/features/staff/list/get-staffs.ts
@@ -1,13 +1,19 @@
 import { db } from "@workspace/db/client";
-import type { SelectStaff } from "@workspace/db/schema/staff";
 import { staffsTable } from "@workspace/db/schema/staff";
-import { desc, ilike, or } from "drizzle-orm";
+import { desc, eq, ilike, or, sql } from "drizzle-orm";
+import { authUsers } from "drizzle-orm/supabase";
 import { cacheLife, cacheTag } from "next/cache";
 import { StaffTag } from "../tag";
 import type { StaffsCondition } from "./schema";
 
+type Staff = {
+	email: string;
+	id: string;
+	name: string;
+};
+
 type GetStaffsResult = {
-	staffs: SelectStaff[];
+	staffs: Staff[];
 	page: number;
 	totalPages: number;
 };
@@ -24,19 +30,29 @@ export async function getStaffs({
 	const whereConditions = keyword
 		? or(
 				ilike(staffsTable.name, `%${keyword}%`),
-				ilike(staffsTable.email, `%${keyword}%`),
+				ilike(authUsers.email, `%${keyword}%`),
 			)
 		: undefined;
 
 	const staffs = await db
-		.select()
+		.select({
+			email: sql<string>`COALESCE(${authUsers.email}, '')`,
+			id: staffsTable.id,
+			name: staffsTable.name,
+		})
 		.from(staffsTable)
+		.leftJoin(authUsers, eq(staffsTable.authUserId, authUsers.id))
 		.where(whereConditions)
 		.orderBy(desc(staffsTable.createdAt))
 		.limit(pageSize)
 		.offset((page - 1) * pageSize);
 
-	const total = await db.$count(staffsTable, whereConditions);
+	const total = await db
+		.select({ count: sql<number>`count(*)` })
+		.from(staffsTable)
+		.leftJoin(authUsers, eq(staffsTable.authUserId, authUsers.id))
+		.where(whereConditions)
+		.then((result) => Number(result[0]?.count ?? 0));
 
 	return {
 		page,

--- a/apps/web/features/staff/list/schema.ts
+++ b/apps/web/features/staff/list/schema.ts
@@ -35,7 +35,7 @@ export function parseStaffsConditionSearchParams(value: unknown) {
 }
 
 export type StaffsListItem = {
+	email: string;
 	id: string;
 	name: string;
-	email: string;
 };

--- a/apps/web/features/staff/list/staffs-presenter.tsx
+++ b/apps/web/features/staff/list/staffs-presenter.tsx
@@ -51,7 +51,7 @@ export function StaffsPresenter({
 									{staff.name}
 								</Link>
 							</TableCell>
-							<TableCell>{staff.email}</TableCell>
+							<TableCell>{staff.email || "-"}</TableCell>
 						</TableRow>
 					))}
 				</TableBody>

--- a/packages/db/drizzle/0009_chilly_trish_tilby.sql
+++ b/packages/db/drizzle/0009_chilly_trish_tilby.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "staffs" ADD COLUMN "auth_user_id" uuid;--> statement-breakpoint
+ALTER TABLE "staffs" ADD CONSTRAINT "staffs_auth_user_id_unique" UNIQUE("auth_user_id");

--- a/packages/db/drizzle/0010_thin_agent_zero.sql
+++ b/packages/db/drizzle/0010_thin_agent_zero.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "staffs" DROP COLUMN "email";

--- a/packages/db/drizzle/meta/0009_snapshot.json
+++ b/packages/db/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,306 @@
+{
+  "id": "5a6f64a4-43b6-4fbd-95c4-5295dd13e054",
+  "prevId": "47386a7c-f43f-4541-aecf-863ae59e8712",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.customers": {
+      "name": "customers",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_note_images": {
+      "name": "customer_note_images",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "customer_note_id": {
+          "name": "customer_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "customer_note_images_customer_note_id_customer_notes_id_fk": {
+          "name": "customer_note_images_customer_note_id_customer_notes_id_fk",
+          "tableFrom": "customer_note_images",
+          "tableTo": "customer_notes",
+          "columnsFrom": [
+            "customer_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "customer_note_images_customer_note_id_display_order_pk": {
+          "name": "customer_note_images_customer_note_id_display_order_pk",
+          "columns": [
+            "customer_note_id",
+            "display_order"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_notes": {
+      "name": "customer_notes",
+      "schema": "",
+      "columns": {
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "staff_id": {
+          "name": "staff_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_customer_notes_customer_created": {
+          "name": "idx_customer_notes_customer_created",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_notes_staff_id": {
+          "name": "idx_customer_notes_staff_id",
+          "columns": [
+            {
+              "expression": "staff_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_notes_customer_id_customers_customer_id_fk": {
+          "name": "customer_notes_customer_id_customers_customer_id_fk",
+          "tableFrom": "customer_notes",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "customer_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_notes_staff_id_staffs_id_fk": {
+          "name": "customer_notes_staff_id_staffs_id_fk",
+          "tableFrom": "customer_notes",
+          "tableTo": "staffs",
+          "columnsFrom": [
+            "staff_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staffs": {
+      "name": "staffs",
+      "schema": "",
+      "columns": {
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "staffs_auth_user_id_unique": {
+          "name": "staffs_auth_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "auth_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/0010_snapshot.json
+++ b/packages/db/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,300 @@
+{
+  "id": "bb40154b-569e-4959-a952-fd5588bbb750",
+  "prevId": "5a6f64a4-43b6-4fbd-95c4-5295dd13e054",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.customers": {
+      "name": "customers",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_note_images": {
+      "name": "customer_note_images",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "customer_note_id": {
+          "name": "customer_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "customer_note_images_customer_note_id_customer_notes_id_fk": {
+          "name": "customer_note_images_customer_note_id_customer_notes_id_fk",
+          "tableFrom": "customer_note_images",
+          "tableTo": "customer_notes",
+          "columnsFrom": [
+            "customer_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "customer_note_images_customer_note_id_display_order_pk": {
+          "name": "customer_note_images_customer_note_id_display_order_pk",
+          "columns": [
+            "customer_note_id",
+            "display_order"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_notes": {
+      "name": "customer_notes",
+      "schema": "",
+      "columns": {
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "staff_id": {
+          "name": "staff_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_customer_notes_customer_created": {
+          "name": "idx_customer_notes_customer_created",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_notes_staff_id": {
+          "name": "idx_customer_notes_staff_id",
+          "columns": [
+            {
+              "expression": "staff_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_notes_customer_id_customers_customer_id_fk": {
+          "name": "customer_notes_customer_id_customers_customer_id_fk",
+          "tableFrom": "customer_notes",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "customer_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_notes_staff_id_staffs_id_fk": {
+          "name": "customer_notes_staff_id_staffs_id_fk",
+          "tableFrom": "customer_notes",
+          "tableTo": "staffs",
+          "columnsFrom": [
+            "staff_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staffs": {
+      "name": "staffs",
+      "schema": "",
+      "columns": {
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "staffs_auth_user_id_unique": {
+          "name": "staffs_auth_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "auth_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -64,6 +64,20 @@
       "when": 1764167277439,
       "tag": "0008_melodic_zemo",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1764384962551,
+      "tag": "0009_chilly_trish_tilby",
+      "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1764387293180,
+      "tag": "0010_thin_agent_zero",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/staff.ts
+++ b/packages/db/src/schema/staff.ts
@@ -1,8 +1,11 @@
 import { pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
 
 export const staffsTable = pgTable("staffs", {
+	// auth.users への外部キー制約を設けない理由:
+	// スタッフ登録時に先にスタッフレコードを作成し、その後 auth user を作成するため
+	// 外部キー制約があると、存在しない auth user への参照でエラーになる
+	authUserId: uuid("auth_user_id").unique(),
 	createdAt: timestamp("created_at").defaultNow().notNull(),
-	email: text("email").notNull(),
 	id: uuid("id").primaryKey().defaultRandom(),
 	name: text("name").notNull(),
 	updatedAt: timestamp("updated_at")

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -162,17 +162,17 @@ const customerSeeds = [
 // スタッフのseedデータ
 const staffSeeds = [
 	{
-		email: "tanaka@staff.example.com",
+		authUserId: "a0000000-0000-0000-0000-000000000001",
 		id: "00000000-0000-0000-0000-000000000001",
 		name: "田中 太郎",
 	},
 	{
-		email: "yamada@staff.example.com",
+		authUserId: "a0000000-0000-0000-0000-000000000002",
 		id: "00000000-0000-0000-0000-000000000002",
 		name: "山田 花子",
 	},
 	{
-		email: "sato@staff.example.com",
+		authUserId: "a0000000-0000-0000-0000-000000000003",
 		id: "00000000-0000-0000-0000-000000000003",
 		name: "佐藤 次郎",
 	},

--- a/packages/supabase/src/seed.ts
+++ b/packages/supabase/src/seed.ts
@@ -3,18 +3,21 @@ import { createClient } from "@supabase/supabase-js";
 const usersFixture = [
 	{
 		email: "test1@example.com",
+		id: "a0000000-0000-0000-0000-000000000001",
 		password: "Test@Pass123",
 		role: "user",
 		staffId: "00000000-0000-0000-0000-000000000001",
 	},
 	{
 		email: "test2@example.com",
+		id: "a0000000-0000-0000-0000-000000000002",
 		password: "Secure@456",
 		role: "user",
 		staffId: "00000000-0000-0000-0000-000000000002",
 	},
 	{
 		email: "admin@example.com",
+		id: "a0000000-0000-0000-0000-000000000003",
 		password: "Admin@789!",
 		role: "admin",
 		staffId: "00000000-0000-0000-0000-000000000003",
@@ -48,6 +51,7 @@ async function seedUsers() {
 				app_metadata: { role: user.role, staffId: user.staffId },
 				email: user.email,
 				email_confirm: true,
+				id: user.id,
 				password: user.password,
 			});
 


### PR DESCRIPTION
- staffsTableからemail列を削除（auth.usersから取得可能なため）
- authUserIdカラムをstaffsTableに追加し、auth.usersと連携
- get-staff-detail.ts/get-staffs.tsでauthUsersとJOINしてemail/roleを取得
- email/roleがnullの場合のデフォルト値を設定（COALESCEを使用）
- スタッフ一覧でメールアドレス検索機能を追加
- register-staff.tsで重複メールアドレスのエラーハンドリングを改善
- テストをregisterStaff/deleteStaff関数を使用するよう更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)