### PR TITLE
ログアウト機能を実装

### DIFF
--- a/apps/web/app/(private)/_components/user-menu.tsx
+++ b/apps/web/app/(private)/_components/user-menu.tsx
@@ -5,10 +5,12 @@ import {
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuItem,
+	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "@workspace/ui/components/dropdown-menu";
 import { User } from "lucide-react";
 import Link from "next/link";
+import { LogoutButton } from "../../../features/auth/logout/logout-button";
 
 export function UserMenu() {
 	return (
@@ -22,6 +24,10 @@ export function UserMenu() {
 			<DropdownMenuContent align="end">
 				<DropdownMenuItem asChild>
 					<Link href="/settings/password">パスワード変更</Link>
+				</DropdownMenuItem>
+				<DropdownMenuSeparator />
+				<DropdownMenuItem asChild>
+					<LogoutButton />
 				</DropdownMenuItem>
 			</DropdownMenuContent>
 		</DropdownMenu>

--- a/apps/web/e2e/logout.e2e.test.ts
+++ b/apps/web/e2e/logout.e2e.test.ts
@@ -1,0 +1,38 @@
+import { test as base, expect, type Page } from "@playwright/test";
+
+type LogoutFixture = {
+	authenticatedPage: Page;
+};
+
+const test = base.extend<LogoutFixture>({
+	authenticatedPage: async ({ page }, use) => {
+		// シードユーザー（admin@example.com）でログイン
+		await page.goto("/login");
+		await page.getByLabel("メールアドレス").fill("admin@example.com");
+		await page.getByRole("textbox", { name: "パスワード" }).fill("Admin@789!");
+		await page.getByRole("button", { name: "ログイン" }).click();
+		await page.waitForURL("/");
+		await use(page);
+	},
+});
+
+test("ログイン後、ログアウトするとログインページにリダイレクトされ、バックしてもホームに戻らない", async ({
+	authenticatedPage,
+}) => {
+	await test.step("ユーザーメニューを開く", async () => {
+		await authenticatedPage
+			.getByRole("button", { name: "ユーザーメニューを開く" })
+			.click();
+	});
+
+	await test.step("ログアウトボタンをクリックしてログインページにリダイレクトされることを確認", async () => {
+		await authenticatedPage.getByRole("button", { name: "ログアウト" }).click();
+		await authenticatedPage.waitForURL("/login");
+	});
+
+	await test.step("ブラウザバックしてもホームページに戻らないことを確認", async () => {
+		await authenticatedPage.goBack();
+		// RedirectType.replace を使用しているため、ホームページには戻らない
+		await expect(authenticatedPage).not.toHaveURL("/");
+	});
+});

--- a/apps/web/features/auth/logout/logout-action.ts
+++ b/apps/web/features/auth/logout/logout-action.ts
@@ -1,0 +1,12 @@
+"use server";
+
+import { RedirectType, redirect } from "next/navigation";
+import { createServerAction } from "../../../libs/create-server-action";
+import { logout } from "./logout";
+
+export const logoutAction = createServerAction(logout, {
+	name: "logoutAction",
+	onSuccess: () => {
+		redirect("/login", RedirectType.replace);
+	},
+});

--- a/apps/web/features/auth/logout/logout-button.tsx
+++ b/apps/web/features/auth/logout/logout-button.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { Button } from "@workspace/ui/components/button";
+import { Loader2 } from "lucide-react";
+import { useTransition } from "react";
+import { logoutAction } from "./logout-action";
+
+export function LogoutButton() {
+	const [isPending, startTransition] = useTransition();
+
+	const handleOnClick = () => {
+		startTransition(async () => {
+			await logoutAction();
+		});
+	};
+
+	return (
+		<Button
+			className="w-full justify-start"
+			disabled={isPending}
+			onClick={handleOnClick}
+			variant="ghost"
+		>
+			{isPending && <Loader2 className="animate-spin" />}
+			ログアウト
+		</Button>
+	);
+}

--- a/apps/web/features/auth/logout/logout.ts
+++ b/apps/web/features/auth/logout/logout.ts
@@ -1,0 +1,9 @@
+import { type Success, succeed } from "@harusame0616/result";
+import { createClient } from "@repo/supabase/nextjs/server";
+
+export async function logout(): Promise<Success<undefined>> {
+	const supabase = await createClient();
+	await supabase.auth.signOut();
+
+	return succeed();
+}

--- a/apps/web/libs/create-server-action.ts
+++ b/apps/web/libs/create-server-action.ts
@@ -68,19 +68,7 @@ type ServerActionErrorMessage =
 	| typeof FORBIDDEN_ERROR_MESSAGE
 	| typeof INTERNAL_SERVER_ERROR_MESSAGE;
 
-// schema なしの場合（引数なし）
-export function createServerAction<TData, TError extends string>(
-	logicFunc: (
-		input: undefined,
-		context: ServerActionContext,
-	) => Promise<Result<TData, TError>>,
-	options: Omit<
-		ServerActionOptions<v.UndefinedSchema<undefined>, TData, TError>,
-		"schema"
-	>,
-): () => Promise<Result<TData, TError | ServerActionErrorMessage>>;
-
-// schema ありの場合（引数あり）
+// schema ありの場合（引数あり）- より特定的なので先に配置
 export function createServerAction<
 	TSchema extends v.GenericSchema,
 	TData,
@@ -94,6 +82,18 @@ export function createServerAction<
 ): (
 	input: v.InferInput<TSchema>,
 ) => Promise<Result<TData, TError | ServerActionErrorMessage>>;
+
+// schema なしの場合（引数なし）
+export function createServerAction<TData, TError extends string>(
+	logicFunc: (
+		input: undefined,
+		context: ServerActionContext,
+	) => Promise<Result<TData, TError>>,
+	options: Omit<
+		ServerActionOptions<v.UndefinedSchema<undefined>, TData, TError>,
+		"schema"
+	>,
+): () => Promise<Result<TData, TError | ServerActionErrorMessage>>;
 
 // 実装
 export function createServerAction<


### PR DESCRIPTION
## Summary
- ユーザーメニューにログアウトボタンを追加
- Supabase Auth の signOut を使用してログアウト処理を実装
- ログアウト後は `/login` にリダイレクト（`RedirectType.replace` で履歴置換）
- `createServerAction` にスキーマなし（引数なし）呼び出しのサポートを追加

## 変更ファイル
- `features/auth/logout/logout.ts` - ログアウトコアロジック
- `features/auth/logout/logout-action.ts` - Server Action
- `features/auth/logout/logout-button.tsx` - ログアウトボタンコンポーネント
- `app/(private)/_components/user-menu.tsx` - ユーザーメニューにログアウト追加
- `libs/create-server-action.ts` - 関数オーバーロード追加

## Test plan
- [x] E2Eテスト追加（`e2e/logout.e2e.test.ts`）
- [x] ログイン → ログアウト → ログインページにリダイレクト
- [x] ブラウザバックでホームページに戻らないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)