### PR TITLE
ログインフォームのUI改善とリファクタリング

### DIFF
--- a/apps/web/app/(public)/login/page.tsx
+++ b/apps/web/app/(public)/login/page.tsx
@@ -5,15 +5,28 @@ import {
 	CardHeader,
 	CardTitle,
 } from "@workspace/ui/components/card";
+import type { Metadata } from "next";
+import Image from "next/image";
 import { LoginForm } from "@/features/auth/login/login-form";
+import Logo from "../../../public/icon-512x512.png";
+
+export const metadata: Metadata = {
+	title: "ログイン",
+};
 
 export default function LoginPage() {
 	return (
-		<main className="flex min-h-screen items-center justify-center p-4 bg-background">
-			<Card className="w-full max-w-sm">
+		<main className="flex flex-col min-h-screen items-center p-4 bg-background">
+			<div className="w-16 mx-auto mt-16">
+				<Image alt="" sizes="64px" src={Logo} />
+			</div>
+			<p className="font-mono text-sm">FORMAWORK.ai</p>
+			<Card className="w-full max-w-sm mt-8">
 				<CardHeader>
-					<CardTitle className="text-2xl">ログイン</CardTitle>
-					<CardDescription>FORMAWORK 顧客カルテへログイン</CardDescription>
+					<CardTitle className="text-2xl mx-auto">ログイン</CardTitle>
+					<CardDescription className="text-sm mx-auto">
+						デモ環境
+					</CardDescription>
 				</CardHeader>
 				<CardContent>
 					<LoginForm />

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -3,7 +3,10 @@ import "@workspace/ui/globals.css";
 
 export const metadata: Metadata = {
 	description: "AI とともに仕事を形作る社内システムプラットフォーム",
-	title: "FORMAWORK.AI",
+	title: {
+		default: "FORMAWORK.ai",
+		template: "%s - FORMAWORK.ai",
+	},
 };
 
 export default function RootLayout({

--- a/apps/web/components/loading-icon.tsx
+++ b/apps/web/components/loading-icon.tsx
@@ -1,0 +1,5 @@
+import { Loader } from "lucide-react";
+
+export function LoadingIcon() {
+	return <Loader aria-hidden className="size-4 animate-spin" />;
+}

--- a/apps/web/features/auth/login/default-user.ts
+++ b/apps/web/features/auth/login/default-user.ts
@@ -1,0 +1,13 @@
+import * as v from "valibot";
+
+export const defaultUserName = v.parse(
+	v.optional(v.string(), ""),
+	// biome-ignore lint/complexity/useLiteralKeys: ts(4111)
+	process.env["NEXT_PUBLIC_DEFAULT_USERNAME"],
+);
+
+export const defaultPassword = v.parse(
+	v.optional(v.string(), ""),
+	// biome-ignore lint/complexity/useLiteralKeys: ts(4111)
+	process.env["NEXT_PUBLIC_DEFAULT_PASSWORD"],
+);

--- a/apps/web/features/auth/login/login-action.ts
+++ b/apps/web/features/auth/login/login-action.ts
@@ -2,7 +2,7 @@
 
 import { RedirectType, redirect } from "next/navigation";
 import { login } from "@/features/auth/login/login";
-import { loginSchema } from "@/features/auth/schema";
+import { loginSchema } from "@/features/auth/login/schema";
 import { createServerAction } from "@/libs/create-server-action";
 
 export const loginAction = createServerAction(login, {

--- a/apps/web/features/auth/login/login-form.browser.test.tsx
+++ b/apps/web/features/auth/login/login-form.browser.test.tsx
@@ -95,7 +95,7 @@ test("送信中はボタンが無効化され、ローディング表示にな�
 	const button = page.getByRole("button", { name: /ログイン中/ });
 
 	await expect.element(button).toBeDisabled();
-	await expect.element(page.getByText("ログイン中...")).toBeInTheDocument();
+	await expect.element(page.getByText("ログイン中")).toBeInTheDocument();
 });
 
 test("認証エラー時にエラーメッセージが表示される", async ({

--- a/apps/web/features/auth/login/login-form.tsx
+++ b/apps/web/features/auth/login/login-form.tsx
@@ -11,39 +11,34 @@ import {
 	FormMessage,
 } from "@workspace/ui/components/form";
 import { Input } from "@workspace/ui/components/input";
-import { Loader2 } from "lucide-react";
-import { useTransition } from "react";
 import { useForm } from "react-hook-form";
-import { type LoginSchema, loginSchema } from "@/features/auth/schema";
+import { LoadingIcon } from "@/components/loading-icon";
+import { type LoginParams, loginSchema } from "@/features/auth/login/schema";
 import { useIsHydrated } from "@/libs/use-is-hydrated";
+import { defaultPassword, defaultUserName } from "./default-user";
 import { loginAction } from "./login-action";
 
 export function LoginForm() {
-	const [isPending, startTransition] = useTransition();
 	const { isHydrated } = useIsHydrated();
 
-	const form = useForm<LoginSchema>({
+	const form = useForm<LoginParams>({
 		defaultValues: {
 			// デモ用に環境変数で初期値を設定できるようにする
-			// biome-ignore lint/complexity/useLiteralKeys: ts(4111)
-			password: process.env["NEXT_PUBLIC_DEFAULT_PASSWORD"] || "",
-			// biome-ignore lint/complexity/useLiteralKeys: ts(4111)
-			username: process.env["NEXT_PUBLIC_DEFAULT_USERNAME"] || "",
+			password: defaultPassword,
+			username: defaultUserName,
 		},
 		resolver: valibotResolver(loginSchema),
 	});
 
-	function onSubmit(values: LoginSchema) {
+	async function onSubmit(values: LoginParams) {
 		form.clearErrors("root");
-		startTransition(async () => {
-			const result = await loginAction(values);
-			if (!result.success) {
-				form.setError("root", {
-					message: result.error,
-				});
-			}
-			// 成功時はredirect()によって自動的にリダイレクトされる
-		});
+		const result = await loginAction(values);
+		if (!result.success) {
+			form.setError("root", {
+				message: result.error,
+			});
+		}
+		// 成功時はredirect()によって自動的にリダイレクトされる
 	}
 
 	return (
@@ -92,13 +87,13 @@ export function LoginForm() {
 				)}
 				<Button
 					className="w-full"
-					disabled={isPending || !isHydrated}
+					disabled={form.formState.isSubmitting || !isHydrated}
 					type="submit"
 				>
-					{isPending ? (
+					{form.formState.isSubmitting ? (
 						<>
-							<Loader2 className="mr-2 size-4 animate-spin" />
-							ログイン中...
+							ログイン中
+							<LoadingIcon />
 						</>
 					) : (
 						"ログイン"

--- a/apps/web/features/auth/login/login.ts
+++ b/apps/web/features/auth/login/login.ts
@@ -1,9 +1,6 @@
 import { fail, type Result, succeed } from "@harusame0616/result";
 import { createClient } from "@repo/supabase/nextjs/server";
-import type * as v from "valibot";
-import type { loginSchema } from "../schema";
-
-type LoginParams = v.InferOutput<typeof loginSchema>;
+import type { LoginParams } from "./schema";
 
 const LoginErrorMessage =
 	"ログインできませんでした。メールアドレス・パスワードを確認し、解決しない場合は時間をおくか管理者にお問い合わせください。" as const;

--- a/apps/web/features/auth/login/schema.ts
+++ b/apps/web/features/auth/login/schema.ts
@@ -11,28 +11,6 @@ const usernameSchema = v.pipe(
 	v.email("有効なメールアドレスを入力してください"),
 );
 
-/**
- * パスワードのバリデーションルール:
- * - 8文字以上64文字以下
- * - 英小文字を含む
- * - 英大文字を含む
- * - 数字を含む
- * - 記号を含む
- */
-const _passwordSchema = v.pipe(
-	v.string("パスワードを入力してください"),
-	v.nonEmpty("パスワードを入力してください"),
-	v.minLength(8, "パスワードは8文字以上である必要があります"),
-	v.maxLength(64, "パスワードは64文字以下である必要があります"),
-	v.regex(/[a-z]/, "パスワードには英小文字を含む必要があります"),
-	v.regex(/[A-Z]/, "パスワードには英大文字を含む必要があります"),
-	v.regex(/[0-9]/, "パスワードには数字を含む必要があります"),
-	v.regex(
-		/[!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~]/,
-		"パスワードには記号を含む必要があります",
-	),
-);
-
 // ログイン時はパスワードの条件が漏洩しないように詳細なバリデーションを行わない
 // ただし DoS 攻撃対策として最大文字数は制限する
 const loginPasswordSchema = v.pipe(
@@ -46,4 +24,4 @@ export const loginSchema = v.object({
 	username: usernameSchema,
 });
 
-export type LoginSchema = v.InferOutput<typeof loginSchema>;
+export type LoginParams = v.InferOutput<typeof loginSchema>;

--- a/packages/ui/src/components/input.tsx
+++ b/packages/ui/src/components/input.tsx
@@ -38,9 +38,9 @@ const PasswordInput = forwardRef<
 	}
 
 	return (
-		<div className="relative w-fit">
+		<div className={cn("relative w-full", className)}>
 			<input
-				className={cn(INPUT_BASE_CLASSES, "pr-10", className)}
+				className={cn(INPUT_BASE_CLASSES, "pr-10")}
 				ref={ref}
 				type={showPassword ? "text" : "password"}
 				{...props}


### PR DESCRIPTION
## Summary
- ログインページにロゴとブランド名（FORMAWORK.ai）を追加
- デモ環境用の表示に変更（カード説明を「デモ環境」に）
- 環境変数のパースをvalibotで行うdefault-user.tsに分離
- フォームの送信状態管理をuseTransitionからreact-hook-formのisSubmittingに統一
- schemaファイルをloginディレクトリに移動し、未使用の_passwordSchemaを削除
- PasswordInputのスタイル修正（w-full対応）
- LoadingIconコンポーネントを新規追加

## Test plan
- [ ] ログインページにロゴとブランド名が表示されることを確認
- [ ] ログインフォームが正常に動作することを確認
- [ ] 送信中にローディングアイコンが表示されることを確認
- [ ] 環境変数でデフォルトユーザー名・パスワードが設定できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)