### PR TITLE
ローディングアイコンを LoadingIcon コンポーネントに統一

### DIFF
--- a/apps/web/components/loading-icon.tsx
+++ b/apps/web/components/loading-icon.tsx
@@ -1,5 +1,8 @@
+import { cn } from "@workspace/ui/lib/utils";
 import { Loader } from "lucide-react";
 
-export function LoadingIcon() {
-	return <Loader aria-hidden className="size-4 animate-spin" />;
+export function LoadingIcon({ className }: { className?: string }) {
+	return (
+		<Loader aria-hidden className={cn("size-4 animate-spin", className)} />
+	);
 }

--- a/apps/web/features/auth/change-password/change-password-form.tsx
+++ b/apps/web/features/auth/change-password/change-password-form.tsx
@@ -12,10 +12,10 @@ import {
 	FormMessage,
 } from "@workspace/ui/components/form";
 import { Input } from "@workspace/ui/components/input";
-import { Loader2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTransition } from "react";
 import { useForm } from "react-hook-form";
+import { LoadingIcon } from "@/components/loading-icon";
 import { useIsHydrated } from "@/libs/use-is-hydrated";
 import { changePasswordAction } from "./change-password-action";
 import { type ChangePasswordParams, changePasswordSchema } from "./schema";
@@ -113,7 +113,7 @@ export function ChangePasswordForm({ disabled }: { disabled?: boolean }) {
 					<Button disabled={isDisabled} type="submit">
 						{isPending ? (
 							<>
-								<Loader2 className="mr-2 size-4 animate-spin" />
+								<LoadingIcon className="mr-2" />
 								変更中...
 							</>
 						) : (

--- a/apps/web/features/auth/login/login-form.tsx
+++ b/apps/web/features/auth/login/login-form.tsx
@@ -92,8 +92,8 @@ export function LoginForm() {
 				>
 					{form.formState.isSubmitting ? (
 						<>
+							<LoadingIcon className="mr-2" />
 							ログイン中
-							<LoadingIcon />
 						</>
 					) : (
 						"ログイン"

--- a/apps/web/features/auth/logout/logout-button.tsx
+++ b/apps/web/features/auth/logout/logout-button.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { Button } from "@workspace/ui/components/button";
-import { Loader2 } from "lucide-react";
 import { useTransition } from "react";
+import { LoadingIcon } from "@/components/loading-icon";
 import { logoutAction } from "./logout-action";
 
 export function LogoutButton() {
@@ -21,7 +21,7 @@ export function LogoutButton() {
 			onClick={handleOnClick}
 			variant="ghost"
 		>
-			{isPending && <Loader2 className="animate-spin" />}
+			{isPending && <LoadingIcon />}
 			ログアウト
 		</Button>
 	);

--- a/apps/web/features/auth/logout/logout-button.tsx
+++ b/apps/web/features/auth/logout/logout-button.tsx
@@ -21,7 +21,7 @@ export function LogoutButton() {
 			onClick={handleOnClick}
 			variant="ghost"
 		>
-			{isPending && <LoadingIcon />}
+			{isPending && <LoadingIcon className="mr-2" />}
 			ログアウト
 		</Button>
 	);

--- a/apps/web/features/customer-note/delete/delete-customer-note-dialog.tsx
+++ b/apps/web/features/customer-note/delete/delete-customer-note-dialog.tsx
@@ -10,9 +10,10 @@ import {
 	DialogTitle,
 	DialogTrigger,
 } from "@workspace/ui/components/dialog";
-import { AlertCircle, Loader2, Trash2 } from "lucide-react";
+import { AlertCircle, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
+import { LoadingIcon } from "@/components/loading-icon";
 import { deleteCustomerNoteAction } from "./delete-customer-note-action";
 
 type DeleteCustomerNoteDialogProps = {
@@ -92,8 +93,8 @@ export function DeleteCustomerNoteDialog({
 					>
 						{isPending ? (
 							<>
+								<LoadingIcon className="mr-2" />
 								削除中
-								<Loader2 className="ml-2 size-4 animate-spin" />
 							</>
 						) : (
 							"削除"

--- a/apps/web/features/customer-note/edit/edit-customer-note-dialog.tsx
+++ b/apps/web/features/customer-note/edit/edit-customer-note-dialog.tsx
@@ -22,12 +22,13 @@ import {
 import { OptionalBadge } from "@workspace/ui/components/optional-badge";
 import { RequiredBadge } from "@workspace/ui/components/required-badge";
 import { Textarea } from "@workspace/ui/components/textarea";
-import { AlertCircle, Edit, Loader2, X } from "lucide-react";
+import { AlertCircle, Edit, X } from "lucide-react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
 import { useForm } from "react-hook-form";
 import * as v from "valibot";
+import { LoadingIcon } from "@/components/loading-icon";
 import { CustomerNoteImageInput } from "@/features/customer-note/list/customer-note-image-input";
 import type { CustomerNoteImageWithUrl } from "@/features/customer-note/list/get-customer-notes";
 import { useImageUpload } from "@/features/customer-note/register/use-image-upload";
@@ -312,8 +313,8 @@ export function EditCustomerNoteDialog({
 							>
 								{isProcessing ? (
 									<>
+										<LoadingIcon className="mr-2" />
 										{isUploading ? "アップロード中" : "更新中"}
-										<Loader2 className="ml-2 size-4 animate-spin" />
 									</>
 								) : (
 									"更新"

--- a/apps/web/features/customer-note/list/customer-note-image-input.tsx
+++ b/apps/web/features/customer-note/list/customer-note-image-input.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { Button } from "@workspace/ui/components/button";
-import { ImageIcon, Loader2, X } from "lucide-react";
+import { ImageIcon, X } from "lucide-react";
 import Image from "next/image";
 import { useCallback, useRef } from "react";
+import { LoadingIcon } from "@/components/loading-icon";
 import type { UploadingImage } from "../register/use-image-upload";
 
 type CustomerNoteImageInputProps = {
@@ -84,7 +85,7 @@ export function CustomerNoteImageInput({
 							{/* ステータスオーバーレイ */}
 							{image.status === "uploading" && (
 								<div className="bg-background/80 absolute inset-0 flex items-center justify-center rounded-md">
-									<Loader2 className="text-primary h-5 w-5 animate-spin" />
+									<LoadingIcon className="text-primary size-5" />
 								</div>
 							)}
 							{image.status === "error" && (

--- a/apps/web/features/customer-note/register/register-customer-note-dialog.tsx
+++ b/apps/web/features/customer-note/register/register-customer-note-dialog.tsx
@@ -22,11 +22,12 @@ import {
 import { OptionalBadge } from "@workspace/ui/components/optional-badge";
 import { RequiredBadge } from "@workspace/ui/components/required-badge";
 import { Textarea } from "@workspace/ui/components/textarea";
-import { AlertCircle, Loader2, Plus } from "lucide-react";
+import { AlertCircle, Plus } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
 import { useForm } from "react-hook-form";
 import * as v from "valibot";
+import { LoadingIcon } from "@/components/loading-icon";
 import { CustomerNoteImageInput } from "../list/customer-note-image-input";
 import { registerCustomerNoteAction } from "./register-customer-note-action";
 import { useImageUpload } from "./use-image-upload";
@@ -234,8 +235,8 @@ export function RegisterCustomerNoteDialog({
 							>
 								{isProcessing ? (
 									<>
+										<LoadingIcon className="mr-2" />
 										{isUploading ? "アップロード中" : "登録中"}
-										<Loader2 className="ml-2 size-4 animate-spin" />
 									</>
 								) : (
 									"登録"

--- a/apps/web/features/customer/delete/delete-customer-dialog.tsx
+++ b/apps/web/features/customer/delete/delete-customer-dialog.tsx
@@ -10,8 +10,9 @@ import {
 	DialogTitle,
 	DialogTrigger,
 } from "@workspace/ui/components/dialog";
-import { AlertCircle, Loader2, Trash2 } from "lucide-react";
+import { AlertCircle, Trash2 } from "lucide-react";
 import { useState, useTransition } from "react";
+import { LoadingIcon } from "@/components/loading-icon";
 import { deleteCustomerAction } from "./delete-customer-action";
 
 type DeleteCustomerDialogProps = {
@@ -88,8 +89,8 @@ export function DeleteCustomerDialog({
 					>
 						{isPending ? (
 							<>
+								<LoadingIcon className="mr-2" />
 								削除中
-								<Loader2 className="ml-2 size-4 animate-spin" />
 							</>
 						) : (
 							"削除"

--- a/apps/web/features/customer/register/edit-customer-form.tsx
+++ b/apps/web/features/customer/register/edit-customer-form.tsx
@@ -14,9 +14,9 @@ import {
 import { Input } from "@workspace/ui/components/input";
 import { OptionalBadge } from "@workspace/ui/components/optional-badge";
 import { RequiredBadge } from "@workspace/ui/components/required-badge";
-import { Loader2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
+import { LoadingIcon } from "@/components/loading-icon";
 import { editCustomerAction } from "@/features/customer/edit/edit-customer-action";
 import { useIsHydrated } from "@/libs/use-is-hydrated";
 import type { EditCustomerParams } from "../edit/schema";
@@ -193,8 +193,8 @@ export function EditCustomerForm(
 						<Button className="min-w-[120px]" disabled={disabled} type="submit">
 							{form.formState.isSubmitting ? (
 								<>
+									<LoadingIcon className="mr-2" />
 									編集中
-									<Loader2 className="ml-2 size-4 animate-spin" />
 								</>
 							) : (
 								"編集する"
@@ -204,7 +204,7 @@ export function EditCustomerForm(
 						<Button className="min-w-[120px]" disabled={disabled} type="submit">
 							{form.formState.isSubmitting ? (
 								<>
-									<Loader2 className="mr-2 size-4 animate-spin" />
+									<LoadingIcon className="mr-2" />
 									登録中...
 								</>
 							) : (

--- a/apps/web/features/staff/delete/delete-staff-dialog.tsx
+++ b/apps/web/features/staff/delete/delete-staff-dialog.tsx
@@ -10,8 +10,9 @@ import {
 	DialogTitle,
 	DialogTrigger,
 } from "@workspace/ui/components/dialog";
-import { AlertCircle, Loader2, Trash2 } from "lucide-react";
+import { AlertCircle, Trash2 } from "lucide-react";
 import { useState, useTransition } from "react";
+import { LoadingIcon } from "@/components/loading-icon";
 import { deleteStaffAction } from "./delete-staff-action";
 
 type DeleteStaffDialogProps = {
@@ -96,8 +97,8 @@ export function DeleteStaffDialog({ staffId }: DeleteStaffDialogProps) {
 					>
 						{isPending ? (
 							<>
+								<LoadingIcon className="mr-2" />
 								削除中
-								<Loader2 className="ml-2 size-4 animate-spin" />
 							</>
 						) : (
 							"削除"

--- a/apps/web/features/staff/register/edit-staff-form.tsx
+++ b/apps/web/features/staff/register/edit-staff-form.tsx
@@ -18,9 +18,9 @@ import {
 	RadioGroupItem,
 } from "@workspace/ui/components/radio-group";
 import { RequiredBadge } from "@workspace/ui/components/required-badge";
-import { Loader2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
+import { LoadingIcon } from "@/components/loading-icon";
 import { UserRole } from "@/features/auth/user/role";
 import { useIsHydrated } from "@/libs/use-is-hydrated";
 import { registerStaffAction } from "./register-staff-action";
@@ -223,7 +223,7 @@ export function EditStaffForm({ disabled: disabledProp }: EditStaffFormProps) {
 					<Button className="min-w-[120px]" disabled={disabled} type="submit">
 						{form.formState.isSubmitting ? (
 							<>
-								<Loader2 className="mr-2 size-4 animate-spin" />
+								<LoadingIcon className="mr-2" />
 								登録中...
 							</>
 						) : (


### PR DESCRIPTION
## Summary
- `Loader2` を直接使用していた12箇所を `LoadingIcon` コンポーネントに置き換え
- `LoadingIcon` に `className` prop を追加してカスタマイズ可能に
- ローディングアイコンの位置をテキストの前に統一（`mr-2` クラス使用）

## Test plan
- [ ] 各フォームの送信時にローディングアイコンが正しく表示されることを確認
- [ ] ローディングアイコンの位置がテキストの前にあることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)