### PR TITLE
Dependabot による依存関係自動更新の導入

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,98 @@
+version: 2
+
+updates:
+  # GitHub Actions の更新
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # npm パッケージの更新（pnpm catalog mode 対応）
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+    open-pull-requests-limit: 10
+    groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+      next:
+        patterns:
+          - "next"
+          - "@next/*"
+      supabase:
+        patterns:
+          - "@supabase/*"
+          - "supabase"
+      drizzle:
+        patterns:
+          - "drizzle-orm"
+          - "drizzle-kit"
+          - "postgres"
+      testing:
+        patterns:
+          - "vitest"
+          - "vitest-browser-react"
+          - "@vitest/*"
+          - "@playwright/*"
+          - "@vitejs/plugin-react"
+      ui:
+        patterns:
+          - "@radix-ui/*"
+          - "class-variance-authority"
+          - "clsx"
+          - "lucide-react"
+          - "tailwind-merge"
+          - "tw-animate-css"
+          - "cmdk"
+          - "embla-carousel-react"
+          - "vaul"
+      styling:
+        patterns:
+          - "tailwindcss"
+          - "@tailwindcss/*"
+      dev-tools:
+        patterns:
+          - "@biomejs/biome"
+          - "typescript"
+          - "@types/node"
+          - "knip"
+          - "cspell"
+          - "@turbo/*"
+          - "tsx"
+      form:
+        patterns:
+          - "react-hook-form"
+          - "@hookform/*"
+          - "valibot"
+      logging:
+        patterns:
+          - "pino"
+          - "pino-pretty"
+      utils:
+        patterns:
+          - "uuid"
+          - "@harusame0616/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,7 @@ updates:
           - "*"
 
   # npm パッケージの更新（pnpm catalog mode 対応）
+  # グループ化されていないパッケージは個別PRとして作成される
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -92,7 +93,3 @@ updates:
         patterns:
           - "pino"
           - "pino-pretty"
-      utils:
-        patterns:
-          - "uuid"
-          - "@harusame0616/*"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,7 +1,7 @@
 name: Dependabot 自動マージ
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
 
 permissions:
@@ -17,17 +17,13 @@ jobs:
     name: Dependabot PR の自動マージ
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # Dependabot の PR のみ対象（二重チェックでセキュリティ強化）
-    if: >-
-      github.actor == 'dependabot[bot]' &&
-      github.event.pull_request.user.login == 'dependabot[bot]'
+    # Dependabot の PR のみ対象
+    if: github.actor == 'dependabot[bot]'
 
     steps:
       - name: Dependabot メタデータ取得
         id: metadata
         uses: dependabot/fetch-metadata@v2
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: 更新情報をログ出力
         run: |
@@ -43,4 +39,4 @@ jobs:
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,40 @@
+name: Dependabot 自動マージ
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: dependabot-auto-merge-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  auto-merge:
+    name: Dependabot PR の自動マージ
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Dependabot の PR のみ対象
+    if: github.actor == 'dependabot[bot]'
+
+    steps:
+      - name: Dependabot メタデータ取得
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: 更新情報をログ出力
+        run: |
+          echo "パッケージエコシステム: ${{ steps.metadata.outputs.package-ecosystem }}"
+          echo "更新タイプ: ${{ steps.metadata.outputs.update-type }}"
+          echo "依存関係名: ${{ steps.metadata.outputs.dependency-names }}"
+
+      - name: 自動マージ有効化
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -17,8 +17,10 @@ jobs:
     name: Dependabot PR の自動マージ
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # Dependabot の PR のみ対象
-    if: github.actor == 'dependabot[bot]'
+    # Dependabot の PR のみ対象（二重チェックでセキュリティ強化）
+    if: >-
+      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.user.login == 'dependabot[bot]'
 
     steps:
       - name: Dependabot メタデータ取得
@@ -29,9 +31,13 @@ jobs:
 
       - name: 更新情報をログ出力
         run: |
+          echo "::group::Dependabot 更新情報"
           echo "パッケージエコシステム: ${{ steps.metadata.outputs.package-ecosystem }}"
-          echo "更新タイプ: ${{ steps.metadata.outputs.update-type }}"
           echo "依存関係名: ${{ steps.metadata.outputs.dependency-names }}"
+          echo "更新タイプ: ${{ steps.metadata.outputs.update-type }}"
+          echo "旧バージョン: ${{ steps.metadata.outputs.previous-version }}"
+          echo "新バージョン: ${{ steps.metadata.outputs.new-version }}"
+          echo "::endgroup::"
 
       - name: 自動マージ有効化
         run: gh pr merge --auto --squash "$PR_URL"

--- a/cspell.json
+++ b/cspell.json
@@ -12,10 +12,12 @@
 	"version": "0.2",
 	"words": [
 		"apikey",
+		"automerge",
 		"biomejs",
 		"clsx",
 		"cmdk",
 		"embla",
+		"endgroup",
 		"FORMAWORK",
 		"halfup",
 		"harusame",


### PR DESCRIPTION
## Summary
- Dependabot設定を追加（月次更新、機能別グループ化、pnpm catalog mode対応）
- 自動マージワークフローを追加（全テストパス時に自動squash merge）

## 追加ファイル
- `.github/dependabot.yml` - Dependabot設定
- `.github/workflows/dependabot-auto-merge.yml` - 自動マージワークフロー

## 手動設定が必要
- Settings > General > Pull Requests で **Allow auto-merge** を有効化

## Test plan
- [ ] dependabot.yml の構文が正しいこと（GitHub上で確認）
- [ ] Allow auto-merge が有効化されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)