### PR TITLE
fix: PNG ファイルを proxy の matcher から除外

### DIFF
--- a/apps/web/e2e/assets.e2e.test.ts
+++ b/apps/web/e2e/assets.e2e.test.ts
@@ -5,7 +5,7 @@ const staticAssets = [
 	"/manifest.webmanifest",
 	"/icon-192x192.png",
 	"/icon-512x512.png",
-	"/apple-touch-icon.png",
+	"/apple-icon.png",
 ];
 
 for (const asset of staticAssets) {

--- a/apps/web/e2e/assets.e2e.test.ts
+++ b/apps/web/e2e/assets.e2e.test.ts
@@ -6,9 +6,6 @@ const staticAssets = [
 	"/icon-192x192.png",
 	"/icon-512x512.png",
 	"/apple-touch-icon.png",
-	"/apple-touch-icon-120x120.png",
-	"/apple-touch-icon-120x120-precomposed.png",
-	"/apple-touch-icon-precomposed.png",
 ];
 
 for (const asset of staticAssets) {

--- a/apps/web/e2e/assets.e2e.test.ts
+++ b/apps/web/e2e/assets.e2e.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "@playwright/test";
+
+const staticAssets = [
+	"/favicon.ico",
+	"/manifest.webmanifest",
+	"/icon-192x192.png",
+	"/icon-512x512.png",
+	"/apple-touch-icon.png",
+	"/apple-touch-icon-120x120.png",
+	"/apple-touch-icon-120x120-precomposed.png",
+	"/apple-touch-icon-precomposed.png",
+];
+
+for (const asset of staticAssets) {
+	test(`${asset} に認証なしでアクセスできる`, async ({ request }) => {
+		const response = await request.get(asset);
+		expect(response.status()).toBe(200);
+	});
+}

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -47,6 +47,6 @@ export async function proxy(request: NextRequest) {
 
 export const config = {
 	matcher: [
-		"/((?!_next/static|_next/image|favicon.ico|manifest.webmanifest|icon-192x192\\.png|icon-512x512\\.png|apple-touch-icon\\.png|apple-touch-icon-120x120\\.png|apple-touch-icon-120x120-precomposed\\.png|apple-touch-icon-precomposed\\.png).*)",
+		"/((?!_next/static|_next/image|favicon.ico|manifest.webmanifest|icon-192x192\\.png|icon-512x512\\.png|apple-icon\\.png).*)",
 	],
 };

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -47,6 +47,6 @@ export async function proxy(request: NextRequest) {
 
 export const config = {
 	matcher: [
-		"/((?!_next/static|_next/image|favicon.ico|manifest.webmanifest).*)",
+		"/((?!_next/static|_next/image|favicon.ico|manifest.webmanifest|icon-192x192\\.png|icon-512x512\\.png|apple-touch-icon\\.png|apple-touch-icon-120x120\\.png|apple-touch-icon-120x120-precomposed\\.png|apple-touch-icon-precomposed\\.png).*)",
 	],
 };

--- a/cspell.json
+++ b/cspell.json
@@ -45,6 +45,7 @@
 		"wcag",
 		"WCAG",
 		"Vali",
-		"pgschema"
+		"pgschema",
+		"precomposed"
 	]
 }


### PR DESCRIPTION
## Summary
- PNG ファイル（apple-icon.png, icon-192x192.png 等）を proxy の matcher から除外
- アイコンファイルへのリクエストが認証チェックを受けてリダイレクトエラー（307）を起こしていた問題を修正

## Test plan
- [ ] `/apple-icon.png` にアクセスしてリダイレクトが発生しないことを確認
- [ ] `/icon-192x192.png` にアクセスしてリダイレクトが発生しないことを確認
- [ ] 通常のページへのアクセスで認証チェックが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)