### PR TITLE
顧客メモリ保護（ロック）機能

### DIFF
--- a/apps/web/e2e/customer-memories.e2e.test.ts
+++ b/apps/web/e2e/customer-memories.e2e.test.ts
@@ -57,30 +57,35 @@ const test = base.extend<Fixtures>({
 				content: "趣味趣向B（重要度低）",
 				customerId,
 				importance: 3,
+				isLocked: false,
 			},
 			{
 				category: MemoryCategory.Conversion,
 				content: "コンバージョン傾向（単独）",
 				customerId,
 				importance: 7,
+				isLocked: false,
 			},
 			{
 				category: MemoryCategory.Personal,
 				content: "パーソナル情報B（重要度低）",
 				customerId,
 				importance: 5,
+				isLocked: false,
 			},
 			{
 				category: MemoryCategory.Preference,
 				content: "趣味趣向A（重要度高）",
 				customerId,
 				importance: 8,
+				isLocked: false,
 			},
 			{
 				category: MemoryCategory.Personal,
 				content: "パーソナル情報A（重要度高）",
 				customerId,
 				importance: 9,
+				isLocked: false,
 			},
 		]);
 
@@ -135,4 +140,35 @@ test("メモリがカテゴリ順・重要度順で表示される", async ({
 	await expect(row5).toContainText("コンバージョン傾向");
 	await expect(row5).toContainText("コンバージョン傾向（単独）");
 	await expect(row5).toContainText("7");
+});
+
+test("ロックボタンでメモリをロック・解除できる", async ({
+	customerMemoriesPage,
+	testCustomer,
+}) => {
+	await customerMemoriesPage.goto(
+		`/customers/${testCustomer.customerId}/memories`,
+	);
+	await expect(customerMemoriesPage.getByRole("table")).toBeVisible();
+
+	const table = customerMemoriesPage.getByRole("table");
+	const rows = table.getByRole("row");
+
+	// 1行目のロックボタンを取得（初期状態は未ロック）
+	const row1 = rows.nth(1);
+	const lockButton = row1.getByRole("button", { name: "ロック" });
+	await expect(lockButton).toBeVisible();
+
+	// ロックボタンをクリック
+	await lockButton.click();
+
+	// ロック状態になったことを確認（ボタンのラベルが「ロック解除」に変わる）
+	const unlockButton = row1.getByRole("button", { name: "ロック解除" });
+	await expect(unlockButton).toBeVisible();
+
+	// 再度クリックして解除
+	await unlockButton.click();
+
+	// 未ロック状態に戻ったことを確認
+	await expect(row1.getByRole("button", { name: "ロック" })).toBeVisible();
 });

--- a/apps/web/e2e/customer-memories.e2e.test.ts
+++ b/apps/web/e2e/customer-memories.e2e.test.ts
@@ -57,35 +57,35 @@ const test = base.extend<Fixtures>({
 				content: "趣味趣向B（重要度低）",
 				customerId,
 				importance: 3,
-				isLocked: false,
+				isProtected: false,
 			},
 			{
 				category: MemoryCategory.Conversion,
 				content: "コンバージョン傾向（単独）",
 				customerId,
 				importance: 7,
-				isLocked: false,
+				isProtected: false,
 			},
 			{
 				category: MemoryCategory.Personal,
 				content: "パーソナル情報B（重要度低）",
 				customerId,
 				importance: 5,
-				isLocked: false,
+				isProtected: false,
 			},
 			{
 				category: MemoryCategory.Preference,
 				content: "趣味趣向A（重要度高）",
 				customerId,
 				importance: 8,
-				isLocked: false,
+				isProtected: false,
 			},
 			{
 				category: MemoryCategory.Personal,
 				content: "パーソナル情報A（重要度高）",
 				customerId,
 				importance: 9,
-				isLocked: false,
+				isProtected: false,
 			},
 		]);
 
@@ -142,7 +142,7 @@ test("メモリがカテゴリ順・重要度順で表示される", async ({
 	await expect(row5).toContainText("7");
 });
 
-test("ロックボタンでメモリをロック・解除できる", async ({
+test("保護ボタンでメモリを保護・解除できる", async ({
 	customerMemoriesPage,
 	testCustomer,
 }) => {
@@ -154,21 +154,21 @@ test("ロックボタンでメモリをロック・解除できる", async ({
 	const table = customerMemoriesPage.getByRole("table");
 	const rows = table.getByRole("row");
 
-	// 1行目のロックボタンを取得（初期状態は未ロック）
+	// 1行目の保護ボタンを取得（初期状態は未保護）
 	const row1 = rows.nth(1);
-	const lockButton = row1.getByRole("button", { name: "ロック" });
+	const lockButton = row1.getByRole("button", { name: "保護" });
 	await expect(lockButton).toBeVisible();
 
-	// ロックボタンをクリック
+	// 保護ボタンをクリック
 	await lockButton.click();
 
-	// ロック状態になったことを確認（ボタンのラベルが「ロック解除」に変わる）
-	const unlockButton = row1.getByRole("button", { name: "ロック解除" });
+	// 保護状態になったことを確認（ボタンのラベルが「保護解除」に変わる）
+	const unlockButton = row1.getByRole("button", { name: "保護解除" });
 	await expect(unlockButton).toBeVisible();
 
 	// 再度クリックして解除
 	await unlockButton.click();
 
-	// 未ロック状態に戻ったことを確認
-	await expect(row1.getByRole("button", { name: "ロック" })).toBeVisible();
+	// 未保護状態に戻ったことを確認
+	await expect(row1.getByRole("button", { name: "保護" })).toBeVisible();
 });

--- a/apps/web/features/customer-memory/generate-memory.ts
+++ b/apps/web/features/customer-memory/generate-memory.ts
@@ -25,6 +25,7 @@ type ExistingMemory = {
 	category: MemoryCategory;
 	content: string;
 	importance: number;
+	isLocked: boolean;
 };
 
 export type GenerateMemoryOperationsParams = {
@@ -191,7 +192,7 @@ ${note.content}`,
 			? existingMemories
 					.map(
 						(memory) =>
-							`- [ID: ${memory.id}] [カテゴリ: ${MEMORY_CATEGORY_LABEL[memory.category]}] [重要度: ${memory.importance}] ${memory.content}`,
+							`- [ID: ${memory.id}] [カテゴリ: ${MEMORY_CATEGORY_LABEL[memory.category]}] [重要度: ${memory.importance}]${memory.isLocked ? " [ロック済み]" : ""} ${memory.content}`,
 					)
 					.join("\n")
 			: "なし";
@@ -264,6 +265,7 @@ ${categoryDescriptions}
 
 ### 重要なルール
 
+- **ロック済みメモリーの保護**: [ロック済み]と表示されているメモリーは更新（update）・削除（delete）禁止
 - **重複禁止**: 既存メモリーと実質的に同じ内容は登録しない
 - **事実ベース**: 接客ノートから確実に読み取れる情報のみ登録
 - **推測禁止**: 曖昧な情報や推測は登録しない

--- a/apps/web/features/customer-memory/generate-memory.ts
+++ b/apps/web/features/customer-memory/generate-memory.ts
@@ -25,7 +25,7 @@ type ExistingMemory = {
 	category: MemoryCategory;
 	content: string;
 	importance: number;
-	isLocked: boolean;
+	isProtected: boolean;
 };
 
 export type GenerateMemoryOperationsParams = {
@@ -192,7 +192,7 @@ ${note.content}`,
 			? existingMemories
 					.map(
 						(memory) =>
-							`- [ID: ${memory.id}] [カテゴリ: ${MEMORY_CATEGORY_LABEL[memory.category]}] [重要度: ${memory.importance}]${memory.isLocked ? " [ロック済み]" : ""} ${memory.content}`,
+							`- [ID: ${memory.id}] [カテゴリ: ${MEMORY_CATEGORY_LABEL[memory.category]}] [重要度: ${memory.importance}]${memory.isProtected ? " [保護済み]" : ""} ${memory.content}`,
 					)
 					.join("\n")
 			: "なし";
@@ -265,7 +265,7 @@ ${categoryDescriptions}
 
 ### 重要なルール
 
-- **ロック済みメモリーの保護**: [ロック済み]と表示されているメモリーは更新（update）・削除（delete）禁止
+- **保護済みメモリーの保護**: [保護済み]と表示されているメモリーは更新（update）・削除（delete）禁止
 - **重複禁止**: 既存メモリーと実質的に同じ内容は登録しない
 - **事実ベース**: 接客ノートから確実に読み取れる情報のみ登録
 - **推測禁止**: 曖昧な情報や推測は登録しない

--- a/apps/web/features/customer-memory/list/customer-memories-container.tsx
+++ b/apps/web/features/customer-memory/list/customer-memories-container.tsx
@@ -11,5 +11,7 @@ export async function CustomerMemoriesContainer({
 	const customerId = await customerIdPromise;
 	const memories = await getCustomerMemories(customerId);
 
-	return <CustomerMemoriesPresenter memories={memories} />;
+	return (
+		<CustomerMemoriesPresenter customerId={customerId} memories={memories} />
+	);
 }

--- a/apps/web/features/customer-memory/list/customer-memories-presenter.browser.test.tsx
+++ b/apps/web/features/customer-memory/list/customer-memories-presenter.browser.test.tsx
@@ -1,21 +1,29 @@
 import { MemoryCategory } from "@workspace/db/schema/customer-memory";
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import { page } from "vitest/browser";
 import { render } from "vitest-browser-react";
 import { CustomerMemoriesPresenter } from "./customer-memories-presenter";
+
+vi.mock("../toggle-lock/toggle-customer-memory-lock-action", () => ({
+	toggleCustomerMemoryLockAction: vi.fn(),
+}));
+
+const TEST_CUSTOMER_ID = "test-customer-id";
 
 const createMockMemory = (
 	id: string,
 	category: number,
 	content: string,
 	importance: number,
+	isLocked = false,
 ) => ({
 	category,
 	content,
 	createdAt: new Date(),
-	customerId: "test-customer-id",
+	customerId: TEST_CUSTOMER_ID,
 	id,
 	importance,
+	isLocked,
 	sourceNoteId: null,
 	updatedAt: new Date(),
 });
@@ -27,7 +35,12 @@ test("100行分表示される", { timeout: 5000 }, async () => {
 		createMockMemory("3", MemoryCategory.Conversion, "テスト内容3", 8),
 	];
 
-	render(<CustomerMemoriesPresenter memories={memories} />);
+	render(
+		<CustomerMemoriesPresenter
+			customerId={TEST_CUSTOMER_ID}
+			memories={memories}
+		/>,
+	);
 
 	const table = page.getByRole("table");
 	await expect.element(table).toBeInTheDocument();
@@ -43,7 +56,12 @@ test("未登録行は内容が「-」で表示される", async () => {
 		createMockMemory("1", MemoryCategory.Personal, "登録済み内容", 5),
 	];
 
-	render(<CustomerMemoriesPresenter memories={memories} />);
+	render(
+		<CustomerMemoriesPresenter
+			customerId={TEST_CUSTOMER_ID}
+			memories={memories}
+		/>,
+	);
 
 	// 登録済みの行が表示されていること
 	await expect.element(page.getByText("登録済み内容")).toBeInTheDocument();
@@ -60,10 +78,18 @@ test("未登録行は内容が「-」で表示される", async () => {
 test("テーブルヘッダーが正しく表示される", async () => {
 	const memories: ReturnType<typeof createMockMemory>[] = [];
 
-	render(<CustomerMemoriesPresenter memories={memories} />);
+	render(
+		<CustomerMemoriesPresenter
+			customerId={TEST_CUSTOMER_ID}
+			memories={memories}
+		/>,
+	);
 
 	await expect
 		.element(page.getByRole("columnheader", { name: "#" }))
+		.toBeInTheDocument();
+	await expect
+		.element(page.getByRole("columnheader", { name: "ロック" }))
 		.toBeInTheDocument();
 	await expect
 		.element(page.getByRole("columnheader", { name: "カテゴリ" }))
@@ -82,7 +108,12 @@ test("カテゴリと重要度が正しく表示される", async () => {
 		createMockMemory("2", MemoryCategory.Preference, "好みの内容", 8),
 	];
 
-	render(<CustomerMemoriesPresenter memories={memories} />);
+	render(
+		<CustomerMemoriesPresenter
+			customerId={TEST_CUSTOMER_ID}
+			memories={memories}
+		/>,
+	);
 
 	// カテゴリラベルが表示される
 	await expect.element(page.getByText("パーソナル情報")).toBeInTheDocument();

--- a/apps/web/features/customer-memory/list/customer-memories-presenter.browser.test.tsx
+++ b/apps/web/features/customer-memory/list/customer-memories-presenter.browser.test.tsx
@@ -15,7 +15,7 @@ const createMockMemory = (
 	category: number,
 	content: string,
 	importance: number,
-	isLocked = false,
+	isProtected = false,
 ) => ({
 	category,
 	content,
@@ -23,7 +23,7 @@ const createMockMemory = (
 	customerId: TEST_CUSTOMER_ID,
 	id,
 	importance,
-	isLocked,
+	isProtected,
 	sourceNoteId: null,
 	updatedAt: new Date(),
 });
@@ -89,7 +89,7 @@ test("テーブルヘッダーが正しく表示される", async () => {
 		.element(page.getByRole("columnheader", { name: "#" }))
 		.toBeInTheDocument();
 	await expect
-		.element(page.getByRole("columnheader", { name: "ロック" }))
+		.element(page.getByRole("columnheader", { name: "保護" }))
 		.toBeInTheDocument();
 	await expect
 		.element(page.getByRole("columnheader", { name: "カテゴリ" }))

--- a/apps/web/features/customer-memory/list/customer-memories-presenter.tsx
+++ b/apps/web/features/customer-memory/list/customer-memories-presenter.tsx
@@ -5,12 +5,15 @@ import {
 } from "@workspace/db/schema/customer-memory";
 import { Card, CardContent } from "@workspace/ui/components/card";
 import { MAX_MEMORIES } from "./constants";
+import { CustomerMemoryLockButton } from "./customer-memory-lock-button";
 
 type CustomerMemoriesPresenterProps = {
+	customerId: string;
 	memories: SelectCustomerMemory[];
 };
 
 export function CustomerMemoriesPresenter({
+	customerId,
 	memories,
 }: CustomerMemoriesPresenterProps) {
 	return (
@@ -33,6 +36,9 @@ export function CustomerMemoriesPresenter({
 							</th>
 							<th className="w-16 py-2 px-2 text-center" scope="col">
 								重要度
+							</th>
+							<th className="w-14 py-2 px-2 text-center" scope="col">
+								保護
 							</th>
 						</tr>
 					</thead>
@@ -71,6 +77,15 @@ export function CustomerMemoriesPresenter({
 									</td>
 									<td className="text-sm text-center hidden sm:table-cell sm:w-16 sm:py-2 sm:px-2">
 										{importance}
+									</td>
+									<td className="ml-auto sm:ml-0 text-center sm:table-cell sm:w-12 sm:py-2 sm:px-2">
+										{memory && (
+											<CustomerMemoryLockButton
+												customerId={customerId}
+												isLocked={memory.isLocked}
+												memoryId={memory.id}
+											/>
+										)}
 									</td>
 								</tr>
 							);

--- a/apps/web/features/customer-memory/list/customer-memories-presenter.tsx
+++ b/apps/web/features/customer-memory/list/customer-memories-presenter.tsx
@@ -82,7 +82,7 @@ export function CustomerMemoriesPresenter({
 										{memory && (
 											<CustomerMemoryLockButton
 												customerId={customerId}
-												isLocked={memory.isLocked}
+												isProtected={memory.isProtected}
 												memoryId={memory.id}
 											/>
 										)}

--- a/apps/web/features/customer-memory/list/customer-memories-skeleton.tsx
+++ b/apps/web/features/customer-memory/list/customer-memories-skeleton.tsx
@@ -25,7 +25,7 @@ export function CustomerMemoriesSkeleton() {
 								重要度
 							</th>
 							<th className="w-12 py-2 px-2 text-center" scope="col">
-								ロック
+								保護
 							</th>
 						</tr>
 					</thead>

--- a/apps/web/features/customer-memory/list/customer-memories-skeleton.tsx
+++ b/apps/web/features/customer-memory/list/customer-memories-skeleton.tsx
@@ -1,5 +1,6 @@
 import { Card, CardContent } from "@workspace/ui/components/card";
 import { Skeleton } from "@workspace/ui/components/skeleton";
+import { MAX_MEMORIES } from "./constants";
 
 export function CustomerMemoriesSkeleton() {
 	return (
@@ -23,10 +24,13 @@ export function CustomerMemoriesSkeleton() {
 							<th className="w-16 py-2 px-2 text-center" scope="col">
 								重要度
 							</th>
+							<th className="w-12 py-2 px-2 text-center" scope="col">
+								ロック
+							</th>
 						</tr>
 					</thead>
 					<tbody>
-						{Array.from({ length: 15 }).map((_, index) => (
+						{Array.from({ length: MAX_MEMORIES }).map((_, index) => (
 							<tr
 								className="border-b last:border-b-0 flex flex-wrap sm:table-row py-2 sm:py-0 min-h-14 sm:min-h-0"
 								key={index}
@@ -52,6 +56,9 @@ export function CustomerMemoriesSkeleton() {
 								</td>
 								<td className="text-sm text-center hidden sm:table-cell sm:w-16 sm:py-2 sm:px-2">
 									<Skeleton className="mt-1 h-4 w-6 mx-auto" />
+								</td>
+								<td className="ml-auto sm:ml-0 text-center sm:table-cell sm:w-12 sm:py-2 sm:px-2">
+									<Skeleton className="h-8 w-8 mx-auto rounded" />
 								</td>
 							</tr>
 						))}

--- a/apps/web/features/customer-memory/list/customer-memory-lock-button.tsx
+++ b/apps/web/features/customer-memory/list/customer-memory-lock-button.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Button } from "@workspace/ui/components/button";
+import { Lock, Unlock } from "lucide-react";
+import { useOptimistic, useTransition } from "react";
+import { toggleCustomerMemoryLockAction } from "../toggle-lock/toggle-customer-memory-lock-action";
+
+type CustomerMemoryLockButtonProps = {
+	customerId: string;
+	isLocked: boolean;
+	memoryId: string;
+};
+
+export function CustomerMemoryLockButton({
+	customerId,
+	isLocked,
+	memoryId,
+}: CustomerMemoryLockButtonProps) {
+	const [isPending, startTransition] = useTransition();
+	const [optimisticIsLocked, setOptimisticIsLocked] = useOptimistic(isLocked);
+
+	function handleToggle() {
+		startTransition(async () => {
+			setOptimisticIsLocked(!optimisticIsLocked);
+			await toggleCustomerMemoryLockAction({ customerId, memoryId });
+		});
+	}
+
+	return (
+		<Button
+			disabled={isPending}
+			onClick={handleToggle}
+			size="sm"
+			variant="ghost"
+		>
+			{optimisticIsLocked ? (
+				<Lock className="h-4 w-4 text-amber-500" />
+			) : (
+				<Unlock className="h-4 w-4 text-muted-foreground" />
+			)}
+			<span className="sr-only">
+				{optimisticIsLocked ? "ロック解除" : "ロック"}
+			</span>
+		</Button>
+	);
+}

--- a/apps/web/features/customer-memory/list/customer-memory-lock-button.tsx
+++ b/apps/web/features/customer-memory/list/customer-memory-lock-button.tsx
@@ -7,21 +7,22 @@ import { toggleCustomerMemoryLockAction } from "../toggle-lock/toggle-customer-m
 
 type CustomerMemoryLockButtonProps = {
 	customerId: string;
-	isLocked: boolean;
+	isProtected: boolean;
 	memoryId: string;
 };
 
 export function CustomerMemoryLockButton({
 	customerId,
-	isLocked,
+	isProtected,
 	memoryId,
 }: CustomerMemoryLockButtonProps) {
 	const [isPending, startTransition] = useTransition();
-	const [optimisticIsLocked, setOptimisticIsLocked] = useOptimistic(isLocked);
+	const [optimisticIsProtected, setOptimisticIsProtected] =
+		useOptimistic(isProtected);
 
 	function handleToggle() {
 		startTransition(async () => {
-			setOptimisticIsLocked(!optimisticIsLocked);
+			setOptimisticIsProtected(!optimisticIsProtected);
 			await toggleCustomerMemoryLockAction({ customerId, memoryId });
 		});
 	}
@@ -33,13 +34,13 @@ export function CustomerMemoryLockButton({
 			size="sm"
 			variant="ghost"
 		>
-			{optimisticIsLocked ? (
+			{optimisticIsProtected ? (
 				<Lock className="h-4 w-4 text-amber-500" />
 			) : (
 				<Unlock className="h-4 w-4 text-muted-foreground" />
 			)}
 			<span className="sr-only">
-				{optimisticIsLocked ? "ロック解除" : "ロック"}
+				{optimisticIsProtected ? "保護解除" : "保護"}
 			</span>
 		</Button>
 	);

--- a/apps/web/features/customer-memory/toggle-lock/toggle-customer-memory-lock-action.ts
+++ b/apps/web/features/customer-memory/toggle-lock/toggle-customer-memory-lock-action.ts
@@ -1,0 +1,23 @@
+"use server";
+
+import { updateTag } from "next/cache";
+import * as v from "valibot";
+import { CustomerTag } from "@/features/customer/tag";
+import { createServerAction } from "@/libs/create-server-action";
+import { toggleCustomerMemoryLock } from "./toggle-customer-memory-lock";
+
+const schema = v.object({
+	customerId: v.pipe(v.string(), v.uuid()),
+	memoryId: v.pipe(v.string(), v.uuid()),
+});
+
+export const toggleCustomerMemoryLockAction = createServerAction(
+	async (input) => toggleCustomerMemoryLock(input.memoryId),
+	{
+		name: "toggleCustomerMemoryLockAction",
+		onSuccess: ({ input }) => {
+			updateTag(CustomerTag.MemoryCrud(input.customerId));
+		},
+		schema,
+	},
+);

--- a/apps/web/features/customer-memory/toggle-lock/toggle-customer-memory-lock.ts
+++ b/apps/web/features/customer-memory/toggle-lock/toggle-customer-memory-lock.ts
@@ -1,0 +1,27 @@
+import { fail, type Result, succeed } from "@harusame0616/result";
+import { db } from "@workspace/db/client";
+import { customerMemoriesTable } from "@workspace/db/schema/customer-memory";
+import { eq } from "drizzle-orm";
+
+export async function toggleCustomerMemoryLock(
+	memoryId: string,
+): Promise<Result<{ isLocked: boolean }, "メモリが存在しません">> {
+	const memories = await db
+		.select({ isLocked: customerMemoriesTable.isLocked })
+		.from(customerMemoriesTable)
+		.where(eq(customerMemoriesTable.id, memoryId))
+		.limit(1);
+
+	if (!memories[0]) {
+		return fail("メモリが存在しません");
+	}
+
+	const newIsLocked = !memories[0].isLocked;
+
+	await db
+		.update(customerMemoriesTable)
+		.set({ isLocked: newIsLocked })
+		.where(eq(customerMemoriesTable.id, memoryId));
+
+	return succeed({ isLocked: newIsLocked });
+}

--- a/apps/web/features/customer-memory/toggle-lock/toggle-customer-memory-lock.ts
+++ b/apps/web/features/customer-memory/toggle-lock/toggle-customer-memory-lock.ts
@@ -5,9 +5,9 @@ import { eq } from "drizzle-orm";
 
 export async function toggleCustomerMemoryLock(
 	memoryId: string,
-): Promise<Result<{ isLocked: boolean }, "メモリが存在しません">> {
+): Promise<Result<{ isProtected: boolean }, "メモリが存在しません">> {
 	const memories = await db
-		.select({ isLocked: customerMemoriesTable.isLocked })
+		.select({ isProtected: customerMemoriesTable.isProtected })
 		.from(customerMemoriesTable)
 		.where(eq(customerMemoriesTable.id, memoryId))
 		.limit(1);
@@ -16,12 +16,12 @@ export async function toggleCustomerMemoryLock(
 		return fail("メモリが存在しません");
 	}
 
-	const newIsLocked = !memories[0].isLocked;
+	const newIsProtected = !memories[0].isProtected;
 
 	await db
 		.update(customerMemoriesTable)
-		.set({ isLocked: newIsLocked })
+		.set({ isProtected: newIsProtected })
 		.where(eq(customerMemoriesTable.id, memoryId));
 
-	return succeed({ isLocked: newIsLocked });
+	return succeed({ isProtected: newIsProtected });
 }

--- a/apps/web/features/customer-memory/update-customer-memories.ts
+++ b/apps/web/features/customer-memory/update-customer-memories.ts
@@ -6,7 +6,7 @@ import {
 	type MemoryCategory,
 } from "@workspace/db/schema/customer-memory";
 import { customerNotesTable } from "@workspace/db/schema/customer-note";
-import { asc, count, desc, eq, inArray } from "drizzle-orm";
+import { and, asc, count, desc, eq, inArray } from "drizzle-orm";
 import { revalidateTag } from "next/cache";
 import * as v from "valibot";
 import { genderSchema } from "@/features/customer/schema";
@@ -67,6 +67,7 @@ async function fetchExistingMemories(customerId: string) {
 			content: customerMemoriesTable.content,
 			id: customerMemoriesTable.id,
 			importance: customerMemoriesTable.importance,
+			isLocked: customerMemoriesTable.isLocked,
 		})
 		.from(customerMemoriesTable)
 		.where(eq(customerMemoriesTable.customerId, customerId))
@@ -105,30 +106,29 @@ async function executeOperation(
 			});
 			break;
 
-		case "update":
-			{
-				const updateData: Record<string, unknown> = {};
-				if (operation.newContent !== undefined) {
-					// biome-ignore lint/complexity/useLiteralKeys: ts4111
-					updateData["content"] = operation.newContent;
-				}
-				if (operation.newImportance !== undefined) {
-					// biome-ignore lint/complexity/useLiteralKeys: ts4111
-					updateData["importance"] = operation.newImportance;
-				}
-				if (Object.keys(updateData).length > 0) {
-					await db
-						.update(customerMemoriesTable)
-						.set(updateData)
-						.where(eq(customerMemoriesTable.id, operation.memoryId));
-					logger.info("メモリー更新", {
-						memoryId: operation.memoryId,
-						reason: operation.reason,
-						updates: updateData,
-					});
-				}
+		case "update": {
+			const updateData: Record<string, unknown> = {};
+			if (operation.newContent !== undefined) {
+				// biome-ignore lint/complexity/useLiteralKeys: ts4111
+				updateData["content"] = operation.newContent;
+			}
+			if (operation.newImportance !== undefined) {
+				// biome-ignore lint/complexity/useLiteralKeys: ts4111
+				updateData["importance"] = operation.newImportance;
+			}
+			if (Object.keys(updateData).length > 0) {
+				await db
+					.update(customerMemoriesTable)
+					.set(updateData)
+					.where(eq(customerMemoriesTable.id, operation.memoryId));
+				logger.info("メモリー更新", {
+					memoryId: operation.memoryId,
+					reason: operation.reason,
+					updates: updateData,
+				});
 			}
 			break;
+		}
 
 		case "delete":
 			await db
@@ -140,6 +140,18 @@ async function executeOperation(
 			});
 			break;
 	}
+}
+
+function filterLockedOperations(
+	operations: MemoryOperation[],
+	lockedMemoryIds: Set<string>,
+): MemoryOperation[] {
+	return operations.filter((op) => {
+		if (op.operation === "create") {
+			return true;
+		}
+		return !lockedMemoryIds.has(op.memoryId);
+	});
 }
 
 async function enforceMemoryLimit(customerId: string): Promise<void> {
@@ -158,7 +170,12 @@ async function enforceMemoryLimit(customerId: string): Promise<void> {
 		const idsToDelete = await db
 			.select({ id: customerMemoriesTable.id })
 			.from(customerMemoriesTable)
-			.where(eq(customerMemoriesTable.customerId, customerId))
+			.where(
+				and(
+					eq(customerMemoriesTable.customerId, customerId),
+					eq(customerMemoriesTable.isLocked, false),
+				),
+			)
 			.orderBy(
 				asc(customerMemoriesTable.importance),
 				asc(customerMemoriesTable.createdAt),
@@ -176,7 +193,7 @@ async function enforceMemoryLimit(customerId: string): Promise<void> {
 
 		logger.info("メモリー件数制限適用", {
 			customerId,
-			deletedCount: deleteCount,
+			deletedCount: idsToDelete.length,
 			previousCount: currentCount,
 		});
 	}
@@ -205,6 +222,9 @@ export async function updateCustomerMemories(
 	}
 
 	const existingMemories = await fetchExistingMemories(customerId);
+	const lockedMemoryIds = new Set(
+		existingMemories.filter((m) => m.isLocked).map((m) => m.id),
+	);
 
 	const params: GenerateMemoryOperationsParams = {
 		customer: {
@@ -223,11 +243,16 @@ export async function updateCustomerMemories(
 	};
 
 	const result = await generateMemoryOperations(params);
+	// プロンプトだけだと AI が守らない可能性もあるため、プログラム的にも保護
+	const executableOperations = filterLockedOperations(
+		result.operations,
+		lockedMemoryIds,
+	);
 
-	if (result.operations.length > 0) {
+	if (executableOperations.length > 0) {
 		const primaryNoteId = targetNotes[0]?.id ?? null;
 		await Promise.allSettled(
-			result.operations.map((op) =>
+			executableOperations.map((op) =>
 				executeOperation(customerId, op, primaryNoteId),
 			),
 		);
@@ -237,7 +262,7 @@ export async function updateCustomerMemories(
 
 	logger.info("メモリー更新完了", {
 		customerId,
-		operationsCount: result.operations.length,
+		executedCount: executableOperations.length,
 	});
 
 	return { operationsCount: result.operations.length };

--- a/apps/web/features/customer-memory/update-customer-memories.ts
+++ b/apps/web/features/customer-memory/update-customer-memories.ts
@@ -67,7 +67,7 @@ async function fetchExistingMemories(customerId: string) {
 			content: customerMemoriesTable.content,
 			id: customerMemoriesTable.id,
 			importance: customerMemoriesTable.importance,
-			isLocked: customerMemoriesTable.isLocked,
+			isProtected: customerMemoriesTable.isProtected,
 		})
 		.from(customerMemoriesTable)
 		.where(eq(customerMemoriesTable.customerId, customerId))
@@ -142,15 +142,15 @@ async function executeOperation(
 	}
 }
 
-function filterLockedOperations(
+function filterProtectedOperations(
 	operations: MemoryOperation[],
-	lockedMemoryIds: Set<string>,
+	protectedMemoryIds: Set<string>,
 ): MemoryOperation[] {
 	return operations.filter((op) => {
 		if (op.operation === "create") {
 			return true;
 		}
-		return !lockedMemoryIds.has(op.memoryId);
+		return !protectedMemoryIds.has(op.memoryId);
 	});
 }
 
@@ -173,7 +173,7 @@ async function enforceMemoryLimit(customerId: string): Promise<void> {
 			.where(
 				and(
 					eq(customerMemoriesTable.customerId, customerId),
-					eq(customerMemoriesTable.isLocked, false),
+					eq(customerMemoriesTable.isProtected, false),
 				),
 			)
 			.orderBy(
@@ -222,8 +222,8 @@ export async function updateCustomerMemories(
 	}
 
 	const existingMemories = await fetchExistingMemories(customerId);
-	const lockedMemoryIds = new Set(
-		existingMemories.filter((m) => m.isLocked).map((m) => m.id),
+	const protectedMemoryIds = new Set(
+		existingMemories.filter((m) => m.isProtected).map((m) => m.id),
 	);
 
 	const params: GenerateMemoryOperationsParams = {
@@ -244,9 +244,9 @@ export async function updateCustomerMemories(
 
 	const result = await generateMemoryOperations(params);
 	// プロンプトだけだと AI が守らない可能性もあるため、プログラム的にも保護
-	const executableOperations = filterLockedOperations(
+	const executableOperations = filterProtectedOperations(
 		result.operations,
-		lockedMemoryIds,
+		protectedMemoryIds,
 	);
 
 	if (executableOperations.length > 0) {

--- a/packages/db/drizzle/0005_kind_gateway.sql
+++ b/packages/db/drizzle/0005_kind_gateway.sql
@@ -1,1 +1,1 @@
-ALTER TABLE "customer_memories" ADD COLUMN "is_locked" boolean DEFAULT false NOT NULL;
+ALTER TABLE "customer_memories" ADD COLUMN "is_protected" boolean DEFAULT false NOT NULL;

--- a/packages/db/drizzle/0005_kind_gateway.sql
+++ b/packages/db/drizzle/0005_kind_gateway.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "customer_memories" ADD COLUMN "is_locked" boolean DEFAULT false NOT NULL;

--- a/packages/db/drizzle/meta/0005_snapshot.json
+++ b/packages/db/drizzle/meta/0005_snapshot.json
@@ -145,8 +145,8 @@
           "notNull": true,
           "default": 5
         },
-        "is_locked": {
-          "name": "is_locked",
+        "is_protected": {
+          "name": "is_protected",
           "type": "boolean",
           "primaryKey": false,
           "notNull": true,

--- a/packages/db/drizzle/meta/0005_snapshot.json
+++ b/packages/db/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,568 @@
+{
+  "id": "c6732b9c-1c89-4412-9e6a-a8b99511a539",
+  "prevId": "44b1a82b-c5f7-40f6-b50d-db0eaad6b5d2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "local.customers": {
+      "name": "customers",
+      "schema": "local",
+      "columns": {
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name_kana": {
+          "name": "first_name_kana",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "gender": {
+          "name": "gender",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name_kana": {
+          "name": "last_name_kana",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remarks": {
+          "name": "remarks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "local.customer_memories": {
+      "name": "customer_memories",
+      "schema": "local",
+      "columns": {
+        "category": {
+          "name": "category",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "importance": {
+          "name": "importance",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "is_locked": {
+          "name": "is_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source_note_id": {
+          "name": "source_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_customer_memories_category": {
+          "name": "idx_customer_memories_category",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_memories_importance": {
+          "name": "idx_customer_memories_importance",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "importance",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_memories_customer_id_customers_customer_id_fk": {
+          "name": "customer_memories_customer_id_customers_customer_id_fk",
+          "tableFrom": "customer_memories",
+          "tableTo": "customers",
+          "schemaTo": "local",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "customer_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "local.customer_note_images": {
+      "name": "customer_note_images",
+      "schema": "local",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "customer_note_id": {
+          "name": "customer_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "customer_note_images_customer_note_id_customer_notes_id_fk": {
+          "name": "customer_note_images_customer_note_id_customer_notes_id_fk",
+          "tableFrom": "customer_note_images",
+          "tableTo": "customer_notes",
+          "schemaTo": "local",
+          "columnsFrom": [
+            "customer_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "customer_note_images_customer_note_id_display_order_pk": {
+          "name": "customer_note_images_customer_note_id_display_order_pk",
+          "columns": [
+            "customer_note_id",
+            "display_order"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "local.customer_notes": {
+      "name": "customer_notes",
+      "schema": "local",
+      "columns": {
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "service_date": {
+          "name": "service_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "staff_id": {
+          "name": "staff_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_customer_notes_customer_created": {
+          "name": "idx_customer_notes_customer_created",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_notes_staff_id": {
+          "name": "idx_customer_notes_staff_id",
+          "columns": [
+            {
+              "expression": "staff_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_notes_customer_id_customers_customer_id_fk": {
+          "name": "customer_notes_customer_id_customers_customer_id_fk",
+          "tableFrom": "customer_notes",
+          "tableTo": "customers",
+          "schemaTo": "local",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "customer_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_notes_staff_id_staffs_staff_id_fk": {
+          "name": "customer_notes_staff_id_staffs_staff_id_fk",
+          "tableFrom": "customer_notes",
+          "tableTo": "staffs",
+          "schemaTo": "local",
+          "columnsFrom": [
+            "staff_id"
+          ],
+          "columnsTo": [
+            "staff_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "local.customer_note_advice": {
+      "name": "customer_note_advice",
+      "schema": "local",
+      "columns": {
+        "advice": {
+          "name": "advice",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "customer_note_id": {
+          "name": "customer_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        }
+      },
+      "indexes": {
+        "idx_customer_note_advice_created": {
+          "name": "idx_customer_note_advice_created",
+          "columns": [
+            {
+              "expression": "customer_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_note_advice_customer_note_id_customer_notes_id_fk": {
+          "name": "customer_note_advice_customer_note_id_customer_notes_id_fk",
+          "tableFrom": "customer_note_advice",
+          "tableTo": "customer_notes",
+          "schemaTo": "local",
+          "columnsFrom": [
+            "customer_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "local.staffs": {
+      "name": "staffs",
+      "schema": "local",
+      "columns": {
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "staff_id": {
+          "name": "staff_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "staffs_auth_user_id_unique": {
+          "name": "staffs_auth_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "auth_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1765495459413,
       "tag": "0004_perfect_kulan_gath",
       "breakpoints": false
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1765614932024,
+      "tag": "0005_kind_gateway",
+      "breakpoints": false
     }
   ]
 }

--- a/packages/db/src/schema/customer-memory.ts
+++ b/packages/db/src/schema/customer-memory.ts
@@ -45,7 +45,7 @@ export const customerMemoriesTable = pgSchema(schemaName).table(
 			.references(() => customersTable.customerId, { onDelete: "cascade" }),
 		id: uuid("id").primaryKey().defaultRandom(),
 		importance: smallint("importance").notNull().default(5),
-		isLocked: boolean("is_locked").notNull().default(false),
+		isProtected: boolean("is_protected").notNull().default(false),
 		sourceNoteId: uuid("source_note_id"),
 		updatedAt: timestamp("updated_at")
 			.defaultNow()

--- a/packages/db/src/schema/customer-memory.ts
+++ b/packages/db/src/schema/customer-memory.ts
@@ -1,4 +1,5 @@
 import {
+	boolean,
 	index,
 	pgSchema,
 	smallint,
@@ -44,6 +45,7 @@ export const customerMemoriesTable = pgSchema(schemaName).table(
 			.references(() => customersTable.customerId, { onDelete: "cascade" }),
 		id: uuid("id").primaryKey().defaultRandom(),
 		importance: smallint("importance").notNull().default(5),
+		isLocked: boolean("is_locked").notNull().default(false),
 		sourceNoteId: uuid("source_note_id"),
 		updatedAt: timestamp("updated_at")
 			.defaultNow()


### PR DESCRIPTION
## Summary
- 顧客メモリに保護（ロック）機能を追加
- 保護されたメモリはAIによる自動更新から除外される
- 保護状態はボタンで切り替え可能（楽観的UI更新対応）

## 変更内容
- **DB**: `is_locked` カラムを `customer_memories` テーブルに追加
- **Server Action**: 保護状態切り替え用の `toggleCustomerMemoryLock` を実装
- **UI**: 保護ボタンコンポーネント（`CustomerMemoryLockButton`）を追加
- **AI制御**: プロンプトとプログラム両方で保護メモリを除外
- **テスト**: ブラウザテスト・E2Eテストを追加

## Test plan
- [ ] 保護ボタンをクリックすると「保護解除」に変わる
- [ ] 再度クリックすると「保護」に戻る
- [ ] 保護されたメモリはAI更新から除外される
- [ ] E2Eテストがパスする

🤖 Generated with [Claude Code](https://claude.com/claude-code)