### PR TITLE
ページ遷移時のオンボーディングハイライト位置ずれを修正

### DIFF
--- a/apps/web/features/onboarding/hooks/use-onboarding.ts
+++ b/apps/web/features/onboarding/hooks/use-onboarding.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useOnborda } from "onborda";
-import { useCallback, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useSyncExternalStore } from "react";
 import { steps } from "../constants/steps";
 
 const STORAGE_KEY = "onboarding-completed";
@@ -47,7 +47,8 @@ function subscribe(callback: () => void): () => void {
 }
 
 export function useOnboarding() {
-	const { currentStep, startOnborda, closeOnborda } = useOnborda();
+	const { currentStep, startOnborda, closeOnborda, isOnbordaVisible } =
+		useOnborda();
 	const isCompleted = useSyncExternalStore(
 		subscribe,
 		getSnapshot,
@@ -68,6 +69,28 @@ export function useOnboarding() {
 			// localStorage が無効な場合は無視
 		}
 	}, []);
+
+	// ページ遷移が伴う場合、最初の要素の位置が関係ない位置でハイライトされてしまう問題がある
+	// おそらくキャッシュ or Activity 周りが関連していそうだが根本的な原因が不明
+	// 暫定対策としてページ遷移を伴う場合は遅延リフレッシュさせることで対処
+	useEffect(() => {
+		if (!isOnbordaVisible) {
+			return;
+		}
+
+		const previousStep = steps[currentStep - 1];
+		if (!previousStep || !previousStep.nextRoute) {
+			return;
+		}
+
+		const timeoutId = setTimeout(() => {
+			refreshHighlight();
+		}, 500);
+
+		return () => {
+			clearInterval(timeoutId);
+		};
+	}, [isOnbordaVisible, refreshHighlight, currentStep]);
 
 	const reset = useCallback(() => {
 		try {


### PR DESCRIPTION
## 変更の目的・背景

ページ遷移を伴うオンボーディングステップで、ハイライトが正しい位置に表示されない問題を修正します。

原因はキャッシュまたは Activity 周りが関連していると推測されますが、根本的な原因は特定できていません。暫定対策として遅延リフレッシュを導入することで対処しました。

## 変更内容の概要

- `useOnboarding` フックに `useEffect` を追加
- 前のステップに `nextRoute` がある場合（ページ遷移後）、500ms 後に `refreshHighlight()` を実行
- `onborda` ライブラリから `isOnbordaVisible` を取得して遷移状態を判定

## 影響範囲

- オンボーディング機能（ユーザーガイドツアー）
- 破壊的変更なし

## 動作確認方法

- [ ] オンボーディングを開始し、ページ遷移を伴うステップ（例: 顧客一覧 → 顧客新規登録）に進む
- [ ] ハイライトが正しい要素に表示されることを確認
- [ ] オンボーディング全体を通して動作に問題がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)