### PR TITLE
claude code github actions の整理

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -60,7 +60,12 @@
 			"allowWrite": ["//tmp/pnpm/store"]
 		},
 		"network": {
-			"allowedDomains": ["api.github.com", "registry.npmjs.org", "github.com"],
+			"allowedDomains": [
+				"api.github.com",
+				"registry.npmjs.org",
+				"github.com",
+				"docs.anthropic.com"
+			],
 			"allowLocalBinding": true
 		}
 	}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,36 +3,28 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+
+concurrency:
+  group: claude-code-review-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   claude-review:
     timeout-minutes: 15
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 
     steps:
-      - name: Checkout repository
+      - name: リポジトリのチェックアウト
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
-      - name: Run Claude Code Review
+      - name: Claude Code レビューの実行
         id: claude-review
         uses: anthropics/claude-code-action@v1
         env:
@@ -44,9 +36,6 @@ jobs:
             - REPO: ${{ github.repository }}
             - PR NUMBER: ${{ github.event.pull_request.number }}
 
-            必ず日本語で回答すること。
             Bash ツールで `gh pr comment` を使用して、レビュー結果を PR のコメントとして残してください。
 
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),mcp__serena,Skill(reviewing-code),Skill(searching-library-reference)"'
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Skill(reviewing-code),Skill(searching-library-reference)"'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,10 @@ on:
   pull_request_review:
     types: [submitted]
 
+concurrency:
+  group: claude-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   claude:
     timeout-minutes: 15
@@ -20,31 +24,21 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      actions: read
     steps:
-      - name: Checkout repository
+      - name: リポジトリのチェックアウト
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
-      - name: Run Claude Code
+      - name: Claude Code の実行
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-
-          # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
-
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
-
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),mcp__context7,mcp__serena"'


### PR DESCRIPTION
## 概要

Claude Code の GitHub Actions ワークフロー（`claude.yml`、`claude-code-review.yml`）の権限設定および `anthropics/claude-code-action@v1` の設定を見直し、push エラーが発生しないよう修正した。

## やったこと

- `.github/workflows/claude.yml` の権限設定を修正
- `.github/workflows/claude-code-review.yml` の権限設定を修正
- `.claude/settings.json` の sandbox `network.allowedDomains` に `docs.anthropic.com` を追加

## 補足

特になし

## 参考

- closes #172