### PR TITLE
Claude Code ワークフローに show_full_output を追加

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -30,6 +30,7 @@ jobs:
         env:
           CONTEXT7_API_KEY: ${{secrets.CONTEXT7_API_KEY}}
         with:
+          show_full_output: true
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             reviewing-code スキルを使って本プルリクのレビューを行ってください。

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,6 +39,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
+          show_full_output: true
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |
             actions: read


### PR DESCRIPTION
## 概要

`claude.yml` および `claude-code-review.yml` に `show_full_output: true` を追加し、Claude Code GitHub Actions のデバッグログ出力を有効化する。

## やったこと

- `claude.yml` に `show_full_output: true` を追加
- `claude-code-review.yml` に `show_full_output: true` を追加

## 補足

#172 の対応（GitHub Actions の権限・設定見直し）の一環として、デバッグ時にアクション全体のログを確認できるようにするための変更。

## 参考

- closes #172