### PR TITLE
claude code github actions の整理（concurrency 修正・show_full_output 追加）

### DIFF
--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -27,7 +27,7 @@ GitHub Actions ワークフローは以下のルールに従うこと。
 ```
 
 ### concurrency 設定
-PR ごとに重複実行を防ぐため、必ず concurrency を設定すること。
+重複実行を防ぐため、原則的に concurrency を設定すること。設定しない場合はワークフローファイルにその理由をコメントで残すこと。
 
 ```yaml
 concurrency:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -30,6 +30,7 @@ jobs:
         env:
           CONTEXT7_API_KEY: ${{secrets.CONTEXT7_API_KEY}}
         with:
+          show_full_output: true
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             reviewing-code スキルを使って本プルリクのレビューを行ってください。

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,9 +10,12 @@ on:
   pull_request_review:
     types: [submitted]
 
-concurrency:
-  group: claude-${{ github.ref }}
-  cancel-in-progress: true
+# concurrency を設定しない理由:
+# issue_comment イベントでは github.ref がデフォルトブランチ（refs/heads/main）になるため、
+# すべての issue/PR への @claude コメントが同一グループに属してしまう。
+# cancel-in-progress: true にすると、Claude Code アクションが投稿する初期ステータスコメントが
+# 新たなワークフロー実行をトリガーし、実行中の正規 run をキャンセルしてしまう。
+# アクション自体が bot コメントの重複実行を検出・スキップする仕組みを持つため、concurrency 不要。
 
 jobs:
   claude:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,6 +39,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
+          show_full_output: true
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |
             actions: read


### PR DESCRIPTION
## 概要

claude.yml の concurrency 設定によって正規 run がキャンセルされる問題を修正し、デバッグ用に `show_full_output` を追加した。

## やったこと

- `claude.yml` の `concurrency` を削除し、削除理由をコメントとして残した
  - `issue_comment` イベントでは `github.ref` がデフォルトブランチになるため、全 issue/PR への @claude コメントが同一グループに集約され、`cancel-in-progress: true` が正規 run をキャンセルしていた
- `claude.yml` と `claude-code-review.yml` に `show_full_output: true` を追加（デバッグログ出力の有効化）
- `.github/workflows/CLAUDE.md` の concurrency ガイドラインを「原則設定・省略時はコメントで理由を記載」に改定

## 補足

特になし

## 参考

- closes #172