### PR TITLE
docs: アドバイス閲覧の認可ポリシーをコメントで明記

### DIFF
--- a/apps/web/app/api/customer-notes/[noteId]/advice/route.ts
+++ b/apps/web/app/api/customer-notes/[noteId]/advice/route.ts
@@ -16,6 +16,9 @@ export async function GET(
 	}
 
 	const { noteId } = await params;
+	// アドバイスは同一サロン内の全従業員が閲覧可能な情報であるため、
+	// noteId の所有者（担当者）と一致するかの認可チェックは行わない。
+	// 認証済みユーザーであれば、他の従業員が作成したアドバイスも参照できる。
 	const advice = await getLatestAdvice(noteId);
 
 	return NextResponse.json(advice);


### PR DESCRIPTION
closes #181

同一サロン内の全従業員がアドバイスを閲覧できる仕様であるため、noteId の所有者確認を行わない理由をコードコメントで補足。

Generated with [Claude Code](https://claude.ai/code)