### PR TITLE
perf: N+1クエリの解消（ノート一覧の画像URL取得・アドバイス取得）

### DIFF
--- a/apps/web/features/customer-note/advice/get-latest-advice.ts
+++ b/apps/web/features/customer-note/advice/get-latest-advice.ts
@@ -1,6 +1,9 @@
 import { db } from "@workspace/db/client";
-import { customerNoteAdviceTable } from "@workspace/db/schema/customer-note-advice";
-import { desc, eq } from "drizzle-orm";
+import {
+	customerNoteAdviceTable,
+	type SelectCustomerNoteAdvice,
+} from "@workspace/db/schema/customer-note-advice";
+import { desc, eq, inArray } from "drizzle-orm";
 import { cacheTag } from "next/cache";
 import { CustomerTag } from "@/features/customer/tag";
 
@@ -16,4 +19,26 @@ export async function getLatestAdvice(customerNoteId: string) {
 		.limit(1);
 
 	return advice ?? null;
+}
+
+/**
+ * 複数のノートIDに対する最新アドバイスを一括取得する
+ * N+1 回避用。呼び出し元のキャッシュに委ねるため、このレイヤーでは "use cache" しない。
+ */
+export async function getLatestAdvices(
+	customerNoteIds: string[],
+): Promise<Map<string, SelectCustomerNoteAdvice>> {
+	if (customerNoteIds.length === 0) return new Map();
+
+	// DISTINCT ON で各ノートの最新アドバイスを1クエリで取得
+	const advices = await db
+		.selectDistinctOn([customerNoteAdviceTable.customerNoteId])
+		.from(customerNoteAdviceTable)
+		.where(inArray(customerNoteAdviceTable.customerNoteId, customerNoteIds))
+		.orderBy(
+			customerNoteAdviceTable.customerNoteId,
+			desc(customerNoteAdviceTable.createdAt),
+		);
+
+	return new Map(advices.map((advice) => [advice.customerNoteId, advice]));
 }

--- a/apps/web/features/customer-note/list/get-customer-note-image-url.ts
+++ b/apps/web/features/customer-note/list/get-customer-note-image-url.ts
@@ -1,34 +1,33 @@
 import { createAdminClient } from "@repo/supabase/admin";
-import { cacheLife } from "next/cache";
 
 const BUCKET_NAME = "customer-note-attachments";
 // 1.5日 = 129600秒
 const SIGNED_URL_EXPIRY_SECONDS = 129600;
 
 /**
- * 顧客ノート画像の閲覧用 signed URL を生成する
- * キャッシュ時間: 1日
- * signed URL 有効期限: 1.5日
+ * 複数の顧客ノート画像の閲覧用 signed URL を一括生成する
+ * N+1 回避用。呼び出し元のキャッシュに委ねるため、このレイヤーでは "use cache" しない。
  */
-export async function getCustomerNoteImageUrl(
-	path: string,
-): Promise<string | null> {
-	"use cache";
-	cacheLife("days");
+export async function getCustomerNoteImageUrls(
+	paths: string[],
+): Promise<Map<string, string | null>> {
+	if (paths.length === 0) return new Map();
 
 	const supabase = createAdminClient();
 
 	const { data, error } = await supabase.storage
 		.from(BUCKET_NAME)
-		.createSignedUrl(path, SIGNED_URL_EXPIRY_SECONDS);
+		.createSignedUrls(paths, SIGNED_URL_EXPIRY_SECONDS);
 
 	if (error) {
-		console.error("Failed to create signed URL for image", {
+		console.error("Failed to create signed URLs for images", {
 			error,
-			path,
+			paths,
 		});
-		return null;
+		return new Map(paths.map((path) => [path, null]));
 	}
 
-	return data.signedUrl;
+	return new Map(
+		data.map(({ path, signedUrl }) => [path, signedUrl ?? null]),
+	);
 }

--- a/apps/web/features/customer-note/list/get-customer-notes.ts
+++ b/apps/web/features/customer-note/list/get-customer-notes.ts
@@ -22,8 +22,8 @@ import {
 } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
 import { CustomerTag } from "@/features/customer/tag";
-import { getLatestAdvice } from "../advice/get-latest-advice";
-import { getCustomerNoteImageUrl } from "./get-customer-note-image-url";
+import { getLatestAdvices } from "../advice/get-latest-advice";
+import { getCustomerNoteImageUrls } from "./get-customer-note-image-url";
 
 export type CustomerNoteSearchCondition = {
 	customerId: string;
@@ -135,27 +135,28 @@ export async function getCustomerNotes(
 		.limit(NOTES_PER_PAGE)
 		.offset(offset);
 
-	// 画像に signed URL を付与し、アドバイスを取得
-	const notesWithSignedUrls: CustomerNoteWithImages[] = await Promise.all(
-		notesWithImages.map(async (note) => {
-			const [imagesWithUrls, advice] = await Promise.all([
-				Promise.all(
-					note.images.map(async (image) => ({
-						createdAt: new Date(image.createdAt),
-						customerNoteId: image.customerNoteId,
-						displayOrder: image.displayOrder,
-						path: image.path,
-						url: await getCustomerNoteImageUrl(image.path),
-					})),
-				),
-				getLatestAdvice(note.customerNoteId),
-			]);
+	// 画像 URL・アドバイスを一括取得して N+1 を解消
+	const allImagePaths = notesWithImages.flatMap((note) =>
+		note.images.map((img) => img.path),
+	);
+	const noteIds = notesWithImages.map((note) => note.customerNoteId);
 
-			return {
-				...note,
-				advice,
-				images: imagesWithUrls,
-			};
+	const [imageUrlMap, adviceMap] = await Promise.all([
+		getCustomerNoteImageUrls(allImagePaths),
+		getLatestAdvices(noteIds),
+	]);
+
+	const notesWithSignedUrls: CustomerNoteWithImages[] = notesWithImages.map(
+		(note) => ({
+			...note,
+			advice: adviceMap.get(note.customerNoteId) ?? null,
+			images: note.images.map((image) => ({
+				createdAt: new Date(image.createdAt),
+				customerNoteId: image.customerNoteId,
+				displayOrder: image.displayOrder,
+				path: image.path,
+				url: imageUrlMap.get(image.path) ?? null,
+			})),
 		}),
 	);
 


### PR DESCRIPTION
closes #178

## 変更内容

- 画像URL取得: `createSignedUrl`（個別）→ `createSignedUrls`（一括）に変更
- アドバイス取得: DISTINCT ON + IN句で一括取得

Generated with [Claude Code](https://claude.ai/code)