### PR TITLE
docs: デフォルト認証情報（NEXT_PUBLIC_DEFAULT_*）の意図をコメントで明記する

### DIFF
--- a/apps/web/.env.sample
+++ b/apps/web/.env.sample
@@ -12,5 +12,7 @@ DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:62022/postgres
 
 AI_GATEWAY_API_KEY="YOUR_API_KEY"
 
+# デモ用途でログイン画面にデフォルト値を表示するための設定です。
+# NEXT_PUBLIC_ プレフィックスは意図的で、クライアントに公開されます。
 NEXT_PUBLIC_DEFAULT_PASSWORD="Admin@789!"
 NEXT_PUBLIC_DEFAULT_USERNAME=admin@example.com

--- a/apps/web/features/auth/login/default-user.ts
+++ b/apps/web/features/auth/login/default-user.ts
@@ -1,5 +1,7 @@
 import * as v from "valibot";
 
+// デモ用途でログイン画面にデフォルト値を表示するための設定です。
+// NEXT_PUBLIC_ プレフィックスは意図的で、クライアントに公開されます。
 export const defaultUserName = v.parse(
 	v.optional(v.string(), ""),
 	process.env["NEXT_PUBLIC_DEFAULT_USERNAME"],


### PR DESCRIPTION
closes #177

NEXT_PUBLIC_DEFAULT_PASSWORD / NEXT_PUBLIC_DEFAULT_USERNAME が NEXT_PUBLIC_ プレフィックスを持つ意図を明確にするコメントを .env.sample と default-user.ts に追加しました。

Generated with [Claude Code](https://claude.ai/code)