### PR TITLE
Claude Code GitHub Actions の allowedTools 設定

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,3 +46,6 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |
             actions: read
+          claude_args: >-
+            --allowed-tools
+            "Bash(git add:*),Bash(git status),Bash(git diff:*),Bash(git log:*),Bash(git commit:*),Bash(git push:*),Bash(git checkout:*),Bash(git branch:*),Bash(git fetch:*),Bash(git stash:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh issue comment:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr create:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh search:*),Bash(gh api:*),Bash(pnpm -w validate:check),Bash(pnpm -w validate:fix),Bash(pnpm -w build),Bash(pnpm -w test:browser),Bash(pnpm -w test:server),Bash(pnpm -w db:generate),Bash(ls:*),Read(*),Write(*),Edit(*),Glob(*),Grep(*),Agent(*),TodoWrite,Skill(*),mcp__github_comment__update_claude_comment"


### PR DESCRIPTION
## 概要

Claude Code GitHub Actions において、プロンプト入力なしで自律的に実行できるよう `allowedTools` を明示的に設定した。

## やったこと

- `claude.yml` の `claude_args` に `--allowed-tools` オプションを追加
- git 操作（add / status / diff / log / commit / push / checkout / branch / fetch / stash）を許可
- gh CLI 操作（issue / PR 閲覧・作成・コメント・検索・API）を許可
- pnpm コマンド（validate:check / validate:fix / build / test:browser / test:server / db:generate）を許可
- ファイル操作ツール（Read / Write / Edit / Glob / Grep / Agent / TodoWrite / Skill）を許可
- MCP ツール（mcp__github_comment__update_claude_comment）を許可

## 補足

`allowedTools` を指定しない場合、Claude Code Action はツール使用ごとにプロンプト確認を求めるため、GitHub Actions 上での自律実行ができない。今回はセキュリティリスクが低く、自律的な開発に必要なコマンドに絞って登録している。

## 参考

- closes #203
- https://github.com/anthropics/claude-code-action/blob/main/docs/capabilities-and-limitations.md#what-claude-cannot-do