### PR TITLE
feat: login ページに OGP メタタグを追加

### DIFF
--- a/apps/web/app/(public)/login/page.tsx
+++ b/apps/web/app/(public)/login/page.tsx
@@ -11,6 +11,14 @@ import { LoginForm } from "@/features/auth/login/login-form";
 import Logo from "../../../public/icon-512x512.png";
 
 export const metadata: Metadata = {
+	description: "AI とともに仕事を形作る社内システムプラットフォーム",
+	openGraph: {
+		description: "AI とともに仕事を形作る社内システムプラットフォーム",
+		images: [{ height: 512, url: "/icon-512x512.png", width: 512 }],
+		siteName: "FORMAWORK.ai",
+		title: "ログイン - FORMAWORK.ai",
+		type: "website",
+	},
 	title: "ログイン",
 };
 

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -4,9 +4,9 @@ import "@workspace/ui/globals.css";
 export const metadata: Metadata = {
 	description: "AI とともに仕事を形作る社内システムプラットフォーム",
 	metadataBase: new URL(
-		process.env.NEXT_PUBLIC_APP_URL ??
-			(process.env.VERCEL_URL
-				? `https://${process.env.VERCEL_URL}`
+		process.env["NEXT_PUBLIC_APP_URL"] ??
+			(process.env["VERCEL_URL"]
+				? `https://${process.env["VERCEL_URL"]}`
 				: "http://localhost:3000"),
 	),
 	title: {

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -3,6 +3,12 @@ import "@workspace/ui/globals.css";
 
 export const metadata: Metadata = {
 	description: "AI とともに仕事を形作る社内システムプラットフォーム",
+	metadataBase: new URL(
+		process.env.NEXT_PUBLIC_APP_URL ??
+			(process.env.VERCEL_URL
+				? `https://${process.env.VERCEL_URL}`
+				: "http://localhost:3000"),
+	),
 	title: {
 		default: "FORMAWORK.ai",
 		template: "%s - FORMAWORK.ai",


### PR DESCRIPTION
fixes #191

## 変更内容

- root layout に metadataBase を追加（NEXT_PUBLIC_APP_URL / VERCEL_URL / localhost フォールバック）
- login ページに openGraph メタタグ（title, description, image, siteName, type）を追加

Generated with [Claude Code](https://claude.ai/code)