### PR TITLE
ban: mcp__next-devtools__browser_eval の使用を禁止し playwright-cli へ誘導

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,17 @@
 	"$schema": "https://json.schemastore.org/claude-code-settings.json",
 	"enableAllProjectMcpServers": true,
 	"hooks": {
+		"PreToolUse": [
+			{
+				"hooks": [
+					{
+						"command": "echo 'mcp__next-devtools__browser_eval は使用禁止です。playwright-cli を使用してください。' >&2 && exit 2",
+						"type": "command"
+					}
+				],
+				"matcher": "mcp__next-devtools__browser_eval"
+			}
+		],
 		"SessionStart": [
 			{
 				"hooks": [


### PR DESCRIPTION
## 概要

Claude Code のフック設定に PreToolUse フックを追加し、`mcp__next-devtools__browser_eval` の使用を禁止する。ブラウザ操作は `playwright-cli` を使用するよう誘導する。

## やったこと

- `.claude/settings.json` に `PreToolUse` フックを追加
- `mcp__next-devtools__browser_eval` が呼ばれた際にエラーメッセージを出力して実行を中断
- エラーメッセージで `playwright-cli` の使用を案内

## 補足

`mcp__next-devtools__browser_eval` は任意の JavaScript をブラウザ上で評価できるため、意図しない副作用のリスクがある。CLAUDE.md でも `playwright-cli` をブラウザ操作の標準ツールとして指定しているため、フックによって強制する。

## 参考

特になし