### PR TITLE
git をサンドボックス外で実行できるよう設定を更新

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -104,7 +104,7 @@
 	"permissions": {
 		"allow": [
 			"Skill(*)",
-			"Bash(gh *)",
+			"Bash(git commit *)",
 			"Bash(pnpm -w test:browser*)",
 			"Bash(pnpm -w test:e2e*)",
 			"Bash(playwright-cli *)"
@@ -140,6 +140,7 @@
 		"enabled": true,
 		"excludedCommands": [
 			"gh:*",
+			"git commit:*",
 			"pnpm -w test:browser:*",
 			"pnpm -w test:e2e:*",
 			"playwright-cli:*"


### PR DESCRIPTION
## 概要

worktree 環境でもコミットできるように `git commit` コマンドをサンドボックス外で実行できるよう権限設定を追加した。


## 補足

特になし

## 参考
