### PR TITLE
GitHub Actions ポリシー対応

### DIFF
--- a/.github/workflows/browser-test.yml
+++ b/.github/workflows/browser-test.yml
@@ -10,6 +10,9 @@ concurrency:
   group: small-browser-test-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   APP_NAME: FORMAWORK.AI
   SERVICE_NAME: web
@@ -25,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
+    # paths-filter によるスキップ設定は省略する。理由: 実行時間が 3 分未満 (約 2 分) のため、
+    # GitHub Actions の 1 分単位課金ではフィルター条件のメンテナンスコストが節約効果に見合わない。
     steps:
       - name: リポジトリのチェックアウト
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,6 +8,9 @@ concurrency:
   group: claude-code-review-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   claude-review:
     timeout-minutes: 15

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,6 +17,9 @@ on:
 # 新たなワークフロー実行をトリガーし、実行中の正規 run をキャンセルしてしまう。
 # アクション自体が bot コメントの重複実行を検出・スキップする仕組みを持つため、concurrency 不要。
 
+permissions:
+  contents: read
+
 jobs:
   claude:
     timeout-minutes: 100

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -10,6 +10,9 @@ concurrency:
   group: e2e-test-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   APP_NAME: FORMAWORK.AI
   SERVICE_NAME: web
@@ -35,23 +38,58 @@ jobs:
       - name: リポジトリのチェックアウト
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: 変更ファイルの検出
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          predicate-quantifier: every # フィルターの条件を AND 条件にするために必要。 default は some で or 条件
+          filters: |
+            web:
+              - 'apps/web/**'
+              - '!**/*.md'
+              - '!apps/web/vitest.config.ts'
+              - '!apps/web/vitest-browser-setup.ts'
+              - '!apps/web/eslint.config.mjs'
+              - '!apps/web/vercel.json'
+              - '!apps/web/components.json'
+            packages:
+              - 'packages/**'
+              - '!**/*.md'
+              - '!packages/ui/tsconfig.lint.json'
+            root-config:
+              - 'pnpm-lock.yaml'
+              - 'package.json'
+              - 'pnpm-workspace.yaml'
+              - '.node-version'
+            workflow:
+              - '.github/workflows/e2e-test.yml'
+
+      - name: 実行要否の判定
+        id: should-run
+        run: echo "result=${{ steps.filter.outputs.web == 'true' || steps.filter.outputs.packages == 'true' || steps.filter.outputs.root-config == 'true' || steps.filter.outputs.workflow == 'true' }}" >> $GITHUB_OUTPUT
+
       - name: pnpm のセットアップ
+        if: steps.should-run.outputs.result == 'true'
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Node.js のセットアップ
+        if: steps.should-run.outputs.result == 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .node-version
           cache: pnpm
 
       - name: 依存関係のインストール
+        if: steps.should-run.outputs.result == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Playwright ブラウザのインストール
+        if: steps.should-run.outputs.result == 'true'
         # userSetupProject で chromium を使うため常に chromium はインストール
         run: pnpm --filter web exec playwright install --with-deps chromium ${{ matrix.browser }}
 
       - name: Supabase CLI のセットアップ
+        if: steps.should-run.outputs.result == 'true'
         uses: supabase/setup-cli@df56b21da46c98abb12a9804e4fb1f657773e333 # v2.0.0
         with:
           # supabase/cli v2.99.0 でリリースアセットの命名規則が変わり、
@@ -61,18 +99,22 @@ jobs:
           version: 2.98.2
 
       - name: Supabase の起動
+        if: steps.should-run.outputs.result == 'true'
         run: |
           pnpm -w supabase:start && pnpm -w supabase:seed
       - name: データベースリセット
+        if: steps.should-run.outputs.result == 'true'
         run: pnpm -w db:reset
       - name: Next.js のビルド
+        if: steps.should-run.outputs.result == 'true'
         run: pnpm --filter web build
 
       - name: E2E テストの実行
+        if: steps.should-run.outputs.result == 'true'
         run: pnpm -w test:e2e --project=${{ matrix.browser }}
 
       - name: テストレポートのアップロード
-        if: failure()
+        if: ${{ failure() && steps.should-run.outputs.result == 'true' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-report-${{ matrix.browser }}
@@ -80,7 +122,7 @@ jobs:
           retention-days: 7
 
       - name: テスト結果アップロード
-        if: failure()
+        if: ${{ failure() && steps.should-run.outputs.result == 'true' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-screenshots-${{ matrix.browser }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -28,6 +28,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
+    permissions:
+      contents: read
+      pull-requests: read # dorny/paths-filter が PR の変更ファイルを取得するために必要
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/server-test.yml
+++ b/.github/workflows/server-test.yml
@@ -10,6 +10,9 @@ concurrency:
   group: server-test-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   APP_NAME: FORMAWORK.AI
   SERVICE_NAME: web
@@ -24,6 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
+    # paths-filter によるスキップ設定は省略する。理由: 実行時間が概ね 3 分未満 (約 2〜3 分) のため、
+    # GitHub Actions の 1 分単位課金ではフィルター条件のメンテナンスコストが節約効果に見合わない。
     steps:
       - name: リポジトリのチェックアウト
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/static-analytics.yml
+++ b/.github/workflows/static-analytics.yml
@@ -10,6 +10,9 @@ concurrency:
   group: static-analytics-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   APP_NAME: FORMAWORK.AI
   SERVICE_NAME: web
@@ -26,20 +29,23 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
+    # paths-filter によるスキップ設定は省略する。理由: format:check (prettier --check .) と cspell . が
+    # ほぼ全ファイルを対象とし、除外できるのはエディタメタデータ程度。フィルター条件のメンテナンスコストが
+    # 得られる節約に見合わないため。
     steps:
-      - name: コードをチェックアウト
+      - name: リポジトリのチェックアウト
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: pnpm をインストール
+      - name: pnpm のセットアップ
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
-      - name: Node.js をセットアップ
+      - name: Node.js のセットアップ
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version-file: ".node-version"
-          cache: "pnpm"
+          node-version-file: .node-version
+          cache: pnpm
 
-      - name: 依存関係をインストール
+      - name: 依存関係のインストール
         run: pnpm install --frozen-lockfile
 
       - name: Supabase CLI のセットアップ


### PR DESCRIPTION
## 概要

GitHub Actions のセキュリティおよび実行コスト最適化ポリシーに対応するため、各ワークフローへ最小権限の `permissions` を明示的に付与し、e2e-test に paths-filter による実行スキップ判定を追加しました。

## やったこと

- 全ワークフロー（browser-test / claude-code-review / claude / e2e-test / server-test / static-analytics）に `permissions: contents: read` を追加し、最小権限の原則を適用
- e2e-test に `dorny/paths-filter` を導入し、対象外パスのみの変更時は実行をスキップ（`apps/web/**`、`packages/**`、ルート設定、ワークフロー自身を対象、ドキュメントや一部設定ファイルを除外）
- 各ステップに `if: steps.should-run.outputs.result == 'true'` を付与し、失敗時のアーティファクトアップロードもスキップ判定とリンク
- 短時間（3 分未満）で実行が完了する browser-test / server-test / static-analytics は、フィルター条件のメンテナンスコストが節約効果に見合わないため paths-filter を見送る旨をコメントとして明記
- static-analytics のステップ名・YAML スタイルを他ワークフローと揃えるよう微修正

## 補足

- paths-filter は `predicate-quantifier: every` を指定して AND 条件で評価しています（デフォルトは some / OR 条件のため明示）。
- claude.yml には concurrency を設定しない方針のコメントが既存にあるため踏襲しています。

## 参考

- 特になし