### PR TITLE
supabase auth を Auth/AuthAdmin ラッパー経由に抽象化

### DIFF
--- a/apps/web/app/api/customer-notes/[noteId]/advice/route.ts
+++ b/apps/web/app/api/customer-notes/[noteId]/advice/route.ts
@@ -1,15 +1,13 @@
-import { createClient } from "@repo/supabase/nextjs/server";
 import { NextResponse } from "next/server";
+import { getAuth } from "@/features/auth/auth";
 import { getLatestAdvice } from "@/features/customer-note/advice/get-latest-advice";
 
 export async function GET(
   _request: Request,
   { params }: { params: Promise<{ noteId: string }> },
 ): Promise<NextResponse> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const auth = await getAuth();
+  const user = await auth.getAuthUser();
 
   if (!user) {
     return new NextResponse(null, { status: 401 });

--- a/apps/web/e2e/staffs.e2e.test.ts
+++ b/apps/web/e2e/staffs.e2e.test.ts
@@ -1,9 +1,9 @@
 import { randomUUID } from "node:crypto";
 import { expect, type Page } from "@playwright/test";
-import { createAdminClient } from "@repo/supabase/admin";
 import { db } from "@workspace/db/client";
 import { staffsTable } from "@workspace/db/schema/staff";
 import { eq } from "drizzle-orm";
+import { getAuthAdmin } from "@/features/auth/auth-admin";
 import { registerStaff } from "@/features/staff/register/register-staff";
 import { testWithAuthenticated } from "./fixtures/authenticated-test";
 
@@ -56,8 +56,8 @@ const test = testWithAuthenticated.extend<{
     await db.delete(staffsTable).where(eq(staffsTable.staffId, staffId));
 
     if (staff?.authUserId) {
-      const supabase = createAdminClient();
-      await supabase.auth.admin.deleteUser(staff.authUserId);
+      const authAdmin = getAuthAdmin();
+      await authAdmin.deleteUser(staff.authUserId);
     }
   },
 });

--- a/apps/web/features/auth/auth-admin.medium.server.test.ts
+++ b/apps/web/features/auth/auth-admin.medium.server.test.ts
@@ -1,0 +1,189 @@
+import { randomUUID } from "node:crypto";
+import { test as base, expect } from "vitest";
+import { getAuthAdmin } from "./auth-admin";
+
+const test = base.extend<{
+  authAdmin: ReturnType<typeof getAuthAdmin>;
+  cleanup: { authUserIds: string[] };
+}>({
+  authAdmin: async ({}, use) => {
+    await use(getAuthAdmin());
+  },
+  cleanup: async ({ authAdmin }, use) => {
+    const authUserIds: string[] = [];
+    await use({ authUserIds });
+    for (const id of authUserIds) {
+      await authAdmin.deleteUser(id);
+    }
+  },
+});
+
+test("createUser でユーザーを作成できる", async ({ authAdmin, cleanup }) => {
+  const uniqueId = randomUUID().slice(0, 8);
+  const email = `auth-admin-create-${uniqueId}@example.com`;
+
+  const result = await authAdmin.createUser({
+    appMetadata: { role: "user", staffId: randomUUID() },
+    email,
+    password: "TestPassword123!",
+  });
+
+  expect(result.success).toBe(true);
+  if (result.success) {
+    expect(result.data.id).toBeDefined();
+    cleanup.authUserIds.push(result.data.id);
+  }
+});
+
+test("createUser で id を指定するとその id でユーザーが作成される", async ({
+  authAdmin,
+  cleanup,
+}) => {
+  const uniqueId = randomUUID().slice(0, 8);
+  const email = `auth-admin-create-id-${uniqueId}@example.com`;
+  const id = randomUUID();
+
+  const result = await authAdmin.createUser({
+    email,
+    id,
+    password: "TestPassword123!",
+  });
+
+  expect(result.success).toBe(true);
+  if (result.success) {
+    expect(result.data.id).toBe(id);
+    cleanup.authUserIds.push(result.data.id);
+  }
+});
+
+test("createUser で既存メールアドレスを指定すると EmailExists が返る", async ({
+  authAdmin,
+  cleanup,
+}) => {
+  const uniqueId = randomUUID().slice(0, 8);
+  const email = `auth-admin-dup-${uniqueId}@example.com`;
+
+  const firstResult = await authAdmin.createUser({
+    email,
+    password: "TestPassword123!",
+  });
+  expect(firstResult.success).toBe(true);
+  if (firstResult.success) {
+    cleanup.authUserIds.push(firstResult.data.id);
+  }
+
+  const secondResult = await authAdmin.createUser({
+    email,
+    password: "TestPassword123!",
+  });
+
+  expect(secondResult.success).toBe(false);
+  if (!secondResult.success) {
+    expect(secondResult.error).toBe("EmailExists");
+  }
+});
+
+test("updateUserById で appMetadata を更新できる", async ({
+  authAdmin,
+  cleanup,
+}) => {
+  const uniqueId = randomUUID().slice(0, 8);
+  const email = `auth-admin-update-${uniqueId}@example.com`;
+
+  const createResult = await authAdmin.createUser({
+    appMetadata: { role: "user", staffId: randomUUID() },
+    email,
+    password: "TestPassword123!",
+  });
+  expect(createResult.success).toBe(true);
+  if (!createResult.success) return;
+  cleanup.authUserIds.push(createResult.data.id);
+
+  const newStaffId = randomUUID();
+  const updateResult = await authAdmin.updateUserById(createResult.data.id, {
+    appMetadata: { role: "admin", staffId: newStaffId },
+  });
+
+  expect(updateResult.success).toBe(true);
+
+  const listResult = await authAdmin.listUsers();
+  expect(listResult.success).toBe(true);
+  if (!listResult.success) return;
+  const user = listResult.data.find((u) => u.id === createResult.data.id);
+  expect(user?.appMetadata.role).toBe("admin");
+  expect(user?.appMetadata.staffId).toBe(newStaffId);
+});
+
+test("updateUserById で email を更新できる", async ({ authAdmin, cleanup }) => {
+  const uniqueId = randomUUID().slice(0, 8);
+  const oldEmail = `auth-admin-update-old-${uniqueId}@example.com`;
+  const newEmail = `auth-admin-update-new-${uniqueId}@example.com`;
+
+  const createResult = await authAdmin.createUser({
+    email: oldEmail,
+    password: "TestPassword123!",
+  });
+  expect(createResult.success).toBe(true);
+  if (!createResult.success) return;
+  cleanup.authUserIds.push(createResult.data.id);
+
+  const updateResult = await authAdmin.updateUserById(createResult.data.id, {
+    email: newEmail,
+  });
+
+  expect(updateResult.success).toBe(true);
+
+  const listResult = await authAdmin.listUsers();
+  if (!listResult.success) return;
+  const user = listResult.data.find((u) => u.id === createResult.data.id);
+  expect(user?.email).toBe(newEmail);
+});
+
+test("deleteUser でユーザーを削除できる", async ({ authAdmin }) => {
+  const uniqueId = randomUUID().slice(0, 8);
+  const email = `auth-admin-delete-${uniqueId}@example.com`;
+
+  const createResult = await authAdmin.createUser({
+    email,
+    password: "TestPassword123!",
+  });
+  expect(createResult.success).toBe(true);
+  if (!createResult.success) return;
+
+  const deleteResult = await authAdmin.deleteUser(createResult.data.id);
+
+  expect(deleteResult.success).toBe(true);
+
+  const listResult = await authAdmin.listUsers();
+  if (!listResult.success) return;
+  const user = listResult.data.find((u) => u.id === createResult.data.id);
+  expect(user).toBeUndefined();
+});
+
+test("listUsers で作成済みユーザーを取得できる", async ({
+  authAdmin,
+  cleanup,
+}) => {
+  const uniqueId = randomUUID().slice(0, 8);
+  const email = `auth-admin-list-${uniqueId}@example.com`;
+  const staffId = randomUUID();
+
+  const createResult = await authAdmin.createUser({
+    appMetadata: { role: "admin", staffId },
+    email,
+    password: "TestPassword123!",
+  });
+  expect(createResult.success).toBe(true);
+  if (!createResult.success) return;
+  cleanup.authUserIds.push(createResult.data.id);
+
+  const listResult = await authAdmin.listUsers();
+  expect(listResult.success).toBe(true);
+  if (!listResult.success) return;
+
+  const user = listResult.data.find((u) => u.id === createResult.data.id);
+  expect(user).toBeDefined();
+  expect(user?.email).toBe(email);
+  expect(user?.appMetadata.role).toBe("admin");
+  expect(user?.appMetadata.staffId).toBe(staffId);
+});

--- a/apps/web/features/auth/auth-admin.ts
+++ b/apps/web/features/auth/auth-admin.ts
@@ -16,11 +16,30 @@ interface AdminUser {
   appMetadata: AdminUserMetadata;
 }
 
-export function getAuthAdmin(): AuthAdmin {
-  return new AuthAdmin(createAdminClient());
+interface AuthAdmin {
+  createUser(params: {
+    id?: string;
+    email: string;
+    password: string;
+    emailConfirm?: boolean;
+    appMetadata?: AdminUserMetadata;
+  }): Promise<Result<{ id: string }, AuthError>>;
+  updateUserById(
+    id: string,
+    params: {
+      email?: string;
+      appMetadata?: AdminUserMetadata;
+    },
+  ): Promise<Result<void, AuthError>>;
+  deleteUser(id: string): Promise<Result<void, AuthError>>;
+  listUsers(): Promise<Result<AdminUser[], AuthError>>;
 }
 
-class AuthAdmin {
+export function getAuthAdmin(): AuthAdmin {
+  return new SupabaseAuthAdmin(createAdminClient());
+}
+
+class SupabaseAuthAdmin implements AuthAdmin {
   constructor(private readonly supabase: AdminSupabaseClient) {}
 
   async createUser(params: {

--- a/apps/web/features/auth/auth-admin.ts
+++ b/apps/web/features/auth/auth-admin.ts
@@ -1,22 +1,21 @@
-import { fail, type Result, succeed } from "@harusame0616/result";
+import type { Result } from "@harusame0616/result";
 import { createAdminClient } from "@repo/supabase/admin";
-import { AuthError } from "./auth-error";
+import type { AuthError } from "./auth-error";
+import { SupabaseAuthAdmin } from "./supabase-auth-admin";
 import type { UserRole } from "./user/role";
 
-type AdminSupabaseClient = ReturnType<typeof createAdminClient>;
-
-interface AdminUserMetadata {
+export interface AdminUserMetadata {
   role?: UserRole;
   staffId?: string;
 }
 
-interface AdminUser {
+export interface AdminUser {
   id: string;
   email: string | undefined;
   appMetadata: AdminUserMetadata;
 }
 
-interface AuthAdmin {
+export interface AuthAdmin {
   createUser(params: {
     id?: string;
     email: string;
@@ -37,71 +36,4 @@ interface AuthAdmin {
 
 export function getAuthAdmin(): AuthAdmin {
   return new SupabaseAuthAdmin(createAdminClient());
-}
-
-class SupabaseAuthAdmin implements AuthAdmin {
-  constructor(private readonly supabase: AdminSupabaseClient) {}
-
-  async createUser(params: {
-    id?: string;
-    email: string;
-    password: string;
-    emailConfirm?: boolean;
-    appMetadata?: AdminUserMetadata;
-  }): Promise<Result<{ id: string }, AuthError>> {
-    const { data, error } = await this.supabase.auth.admin.createUser({
-      app_metadata: params.appMetadata,
-      email: params.email,
-      email_confirm: params.emailConfirm ?? true,
-      id: params.id,
-      password: params.password,
-    });
-
-    if (error) {
-      if (error.code === "email_exists") {
-        return fail(AuthError.EmailExists);
-      }
-      return fail(AuthError.CreateFailed);
-    }
-    return succeed({ id: data.user.id });
-  }
-
-  async updateUserById(
-    id: string,
-    params: {
-      email?: string;
-      appMetadata?: AdminUserMetadata;
-    },
-  ): Promise<Result<void, AuthError>> {
-    const { error } = await this.supabase.auth.admin.updateUserById(id, {
-      app_metadata: params.appMetadata,
-      email: params.email,
-    });
-    if (error) {
-      return fail(AuthError.UpdateFailed);
-    }
-    return succeed();
-  }
-
-  async deleteUser(id: string): Promise<Result<void, AuthError>> {
-    const { error } = await this.supabase.auth.admin.deleteUser(id);
-    if (error) {
-      return fail(AuthError.DeleteFailed);
-    }
-    return succeed();
-  }
-
-  async listUsers(): Promise<Result<AdminUser[], AuthError>> {
-    const { data, error } = await this.supabase.auth.admin.listUsers();
-    if (error) {
-      return fail(AuthError.ListFailed);
-    }
-    return succeed(
-      data.users.map((user) => ({
-        appMetadata: (user.app_metadata ?? {}) as AdminUserMetadata,
-        email: user.email,
-        id: user.id,
-      })),
-    );
-  }
 }

--- a/apps/web/features/auth/auth-admin.ts
+++ b/apps/web/features/auth/auth-admin.ts
@@ -1,0 +1,88 @@
+import { fail, type Result, succeed } from "@harusame0616/result";
+import { createAdminClient } from "@repo/supabase/admin";
+import { AuthError } from "./auth-error";
+import type { UserRole } from "./user/role";
+
+type AdminSupabaseClient = ReturnType<typeof createAdminClient>;
+
+interface AdminUserMetadata {
+  role?: UserRole;
+  staffId?: string;
+}
+
+interface AdminUser {
+  id: string;
+  email: string | undefined;
+  appMetadata: AdminUserMetadata;
+}
+
+export function getAuthAdmin(): AuthAdmin {
+  return new AuthAdmin(createAdminClient());
+}
+
+class AuthAdmin {
+  constructor(private readonly supabase: AdminSupabaseClient) {}
+
+  async createUser(params: {
+    id?: string;
+    email: string;
+    password: string;
+    emailConfirm?: boolean;
+    appMetadata?: AdminUserMetadata;
+  }): Promise<Result<{ id: string }, AuthError>> {
+    const { data, error } = await this.supabase.auth.admin.createUser({
+      app_metadata: params.appMetadata,
+      email: params.email,
+      email_confirm: params.emailConfirm ?? true,
+      id: params.id,
+      password: params.password,
+    });
+
+    if (error) {
+      if (error.code === "email_exists") {
+        return fail(AuthError.EmailExists);
+      }
+      return fail(AuthError.CreateFailed);
+    }
+    return succeed({ id: data.user.id });
+  }
+
+  async updateUserById(
+    id: string,
+    params: {
+      email?: string;
+      appMetadata?: AdminUserMetadata;
+    },
+  ): Promise<Result<void, AuthError>> {
+    const { error } = await this.supabase.auth.admin.updateUserById(id, {
+      app_metadata: params.appMetadata,
+      email: params.email,
+    });
+    if (error) {
+      return fail(AuthError.UpdateFailed);
+    }
+    return succeed();
+  }
+
+  async deleteUser(id: string): Promise<Result<void, AuthError>> {
+    const { error } = await this.supabase.auth.admin.deleteUser(id);
+    if (error) {
+      return fail(AuthError.DeleteFailed);
+    }
+    return succeed();
+  }
+
+  async listUsers(): Promise<Result<AdminUser[], AuthError>> {
+    const { data, error } = await this.supabase.auth.admin.listUsers();
+    if (error) {
+      return fail(AuthError.ListFailed);
+    }
+    return succeed(
+      data.users.map((user) => ({
+        appMetadata: (user.app_metadata ?? {}) as AdminUserMetadata,
+        email: user.email,
+        id: user.id,
+      })),
+    );
+  }
+}

--- a/apps/web/features/auth/auth-error.ts
+++ b/apps/web/features/auth/auth-error.ts
@@ -1,0 +1,12 @@
+export const AuthError = {
+  InvalidCredentials: "InvalidCredentials",
+  SessionExpired: "SessionExpired",
+  UpdateFailed: "UpdateFailed",
+  EmailExists: "EmailExists",
+  CreateFailed: "CreateFailed",
+  DeleteFailed: "DeleteFailed",
+  SignOutFailed: "SignOutFailed",
+  ListFailed: "ListFailed",
+  Unknown: "Unknown",
+} as const;
+export type AuthError = (typeof AuthError)[keyof typeof AuthError];

--- a/apps/web/features/auth/auth.ts
+++ b/apps/web/features/auth/auth.ts
@@ -1,0 +1,111 @@
+import { fail, type Result, succeed } from "@harusame0616/result";
+import { createClient } from "@repo/supabase/nextjs/server";
+import { AuthError } from "./auth-error";
+import { UserRole } from "./user/role";
+
+export { AuthError } from "./auth-error";
+
+type SupabaseClient = Awaited<ReturnType<typeof createClient>>;
+
+export interface AuthUser {
+  role: UserRole;
+  staffId: string | null;
+}
+
+interface AppMetadata {
+  role?: UserRole;
+  staffId?: string;
+}
+
+function toAuthUserRole(value: unknown): UserRole {
+  switch (value) {
+    case UserRole.Admin: {
+      return UserRole.Admin;
+    }
+    case UserRole.User:
+    case undefined: {
+      return UserRole.User;
+    }
+    default: {
+      throw new Error("不明なロールです。");
+    }
+  }
+}
+
+export async function getAuth(): Promise<Auth> {
+  return new Auth(await createClient());
+}
+
+class Auth {
+  constructor(private readonly supabase: SupabaseClient) {}
+
+  async signInWithPassword({
+    email,
+    password,
+  }: {
+    email: string;
+    password: string;
+  }): Promise<Result<void, AuthError>> {
+    const { error } = await this.supabase.auth.signInWithPassword({
+      email,
+      password,
+    });
+    if (error) {
+      return fail(AuthError.InvalidCredentials);
+    }
+    return succeed();
+  }
+
+  async signOut(): Promise<Result<void, AuthError>> {
+    const { error } = await this.supabase.auth.signOut();
+    if (error) {
+      return fail(AuthError.SignOutFailed);
+    }
+    return succeed();
+  }
+
+  async getAuthUser(): Promise<AuthUser | null> {
+    const {
+      data: { user },
+    } = await this.supabase.auth.getUser();
+    if (!user) {
+      return null;
+    }
+
+    const metadata = user.app_metadata as AppMetadata | undefined;
+    return {
+      role: toAuthUserRole(metadata?.role),
+      staffId: metadata?.staffId ?? null,
+    };
+  }
+
+  async verifyCurrentPassword(
+    currentPassword: string,
+  ): Promise<Result<void, AuthError>> {
+    const {
+      data: { user },
+    } = await this.supabase.auth.getUser();
+    if (!user?.email) {
+      return fail(AuthError.SessionExpired);
+    }
+
+    const { error } = await this.supabase.auth.signInWithPassword({
+      email: user.email,
+      password: currentPassword,
+    });
+    if (error) {
+      return fail(AuthError.InvalidCredentials);
+    }
+    return succeed();
+  }
+
+  async updatePassword(newPassword: string): Promise<Result<void, AuthError>> {
+    const { error } = await this.supabase.auth.updateUser({
+      password: newPassword,
+    });
+    if (error) {
+      return fail(AuthError.UpdateFailed);
+    }
+    return succeed();
+  }
+}

--- a/apps/web/features/auth/auth.ts
+++ b/apps/web/features/auth/auth.ts
@@ -1,23 +1,17 @@
-import { fail, type Result, succeed } from "@harusame0616/result";
+import type { Result } from "@harusame0616/result";
 import { createClient } from "@repo/supabase/nextjs/server";
-import { AuthError } from "./auth-error";
-import { UserRole } from "./user/role";
+import type { AuthError } from "./auth-error";
+import { SupabaseAuth } from "./supabase-auth";
+import type { UserRole } from "./user/role";
 
 export { AuthError } from "./auth-error";
-
-type SupabaseClient = Awaited<ReturnType<typeof createClient>>;
 
 export interface AuthUser {
   role: UserRole;
   staffId: string | null;
 }
 
-interface AppMetadata {
-  role?: UserRole;
-  staffId?: string;
-}
-
-interface Auth {
+export interface Auth {
   signInWithPassword(params: {
     email: string;
     password: string;
@@ -30,95 +24,6 @@ interface Auth {
   updatePassword(newPassword: string): Promise<Result<void, AuthError>>;
 }
 
-function toAuthUserRole(value: unknown): UserRole {
-  switch (value) {
-    case UserRole.Admin: {
-      return UserRole.Admin;
-    }
-    case UserRole.User:
-    case undefined: {
-      return UserRole.User;
-    }
-    default: {
-      throw new Error("不明なロールです。");
-    }
-  }
-}
-
 export async function getAuth(): Promise<Auth> {
   return new SupabaseAuth(await createClient());
-}
-
-class SupabaseAuth implements Auth {
-  constructor(private readonly supabase: SupabaseClient) {}
-
-  async signInWithPassword({
-    email,
-    password,
-  }: {
-    email: string;
-    password: string;
-  }): Promise<Result<void, AuthError>> {
-    const { error } = await this.supabase.auth.signInWithPassword({
-      email,
-      password,
-    });
-    if (error) {
-      return fail(AuthError.InvalidCredentials);
-    }
-    return succeed();
-  }
-
-  async signOut(): Promise<Result<void, AuthError>> {
-    const { error } = await this.supabase.auth.signOut();
-    if (error) {
-      return fail(AuthError.SignOutFailed);
-    }
-    return succeed();
-  }
-
-  async getAuthUser(): Promise<AuthUser | null> {
-    const {
-      data: { user },
-    } = await this.supabase.auth.getUser();
-    if (!user) {
-      return null;
-    }
-
-    const metadata = user.app_metadata as AppMetadata | undefined;
-    return {
-      role: toAuthUserRole(metadata?.role),
-      staffId: metadata?.staffId ?? null,
-    };
-  }
-
-  async verifyCurrentPassword(
-    currentPassword: string,
-  ): Promise<Result<void, AuthError>> {
-    const {
-      data: { user },
-    } = await this.supabase.auth.getUser();
-    if (!user?.email) {
-      return fail(AuthError.SessionExpired);
-    }
-
-    const { error } = await this.supabase.auth.signInWithPassword({
-      email: user.email,
-      password: currentPassword,
-    });
-    if (error) {
-      return fail(AuthError.InvalidCredentials);
-    }
-    return succeed();
-  }
-
-  async updatePassword(newPassword: string): Promise<Result<void, AuthError>> {
-    const { error } = await this.supabase.auth.updateUser({
-      password: newPassword,
-    });
-    if (error) {
-      return fail(AuthError.UpdateFailed);
-    }
-    return succeed();
-  }
 }

--- a/apps/web/features/auth/auth.ts
+++ b/apps/web/features/auth/auth.ts
@@ -17,6 +17,19 @@ interface AppMetadata {
   staffId?: string;
 }
 
+interface Auth {
+  signInWithPassword(params: {
+    email: string;
+    password: string;
+  }): Promise<Result<void, AuthError>>;
+  signOut(): Promise<Result<void, AuthError>>;
+  getAuthUser(): Promise<AuthUser | null>;
+  verifyCurrentPassword(
+    currentPassword: string,
+  ): Promise<Result<void, AuthError>>;
+  updatePassword(newPassword: string): Promise<Result<void, AuthError>>;
+}
+
 function toAuthUserRole(value: unknown): UserRole {
   switch (value) {
     case UserRole.Admin: {
@@ -33,10 +46,10 @@ function toAuthUserRole(value: unknown): UserRole {
 }
 
 export async function getAuth(): Promise<Auth> {
-  return new Auth(await createClient());
+  return new SupabaseAuth(await createClient());
 }
 
-class Auth {
+class SupabaseAuth implements Auth {
   constructor(private readonly supabase: SupabaseClient) {}
 
   async signInWithPassword({

--- a/apps/web/features/auth/change-password/change-password.medium.server.test.ts
+++ b/apps/web/features/auth/change-password/change-password.medium.server.test.ts
@@ -1,20 +1,17 @@
 import { randomUUID } from "node:crypto";
-import { createAdminClient } from "@repo/supabase/admin";
-import { createClient } from "@repo/supabase/nextjs/server";
 import { db } from "@workspace/db/client";
 import { staffsTable } from "@workspace/db/schema/staff";
 import { eq } from "drizzle-orm";
 import { test as base, expect, vi } from "vitest";
+import { AuthError, getAuth } from "@/features/auth/auth";
+import { getAuthAdmin } from "@/features/auth/auth-admin";
 import { changePassword } from "./change-password";
 
-// createClient をモックして、テスト用のSupabaseクライアントを返す
-vi.mock("@repo/supabase/nextjs/server", async () => {
-  const { createAdminClient } = await import("@repo/supabase/admin");
+vi.mock("@/features/auth/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/auth/auth")>();
   return {
-    createClient: vi.fn().mockImplementation(async () => {
-      // テスト用のクライアントを返す（admin clientを使用）
-      return createAdminClient();
-    }),
+    ...actual,
+    getAuth: vi.fn(),
   };
 });
 
@@ -27,23 +24,22 @@ const test = base.extend<{
     const staffIds: string[] = [];
     await use({ authUserIds, staffIds });
 
-    const supabase = createAdminClient();
+    const authAdmin = getAuthAdmin();
     for (const staffId of staffIds) {
       await db.delete(staffsTable).where(eq(staffsTable.staffId, staffId));
     }
     for (const authUserId of authUserIds) {
-      await supabase.auth.admin.deleteUser(authUserId);
+      await authAdmin.deleteUser(authUserId);
     }
   },
   testUser: async ({ cleanup }, use) => {
-    const supabase = createAdminClient();
+    const authAdmin = getAuthAdmin();
     const uniqueId = randomUUID().slice(0, 8);
     const email = `change-password-test-${uniqueId}@example.com`;
     const password = "Test@Pass123";
     const staffId = randomUUID();
     const authUserId = randomUUID();
 
-    // スタッフを作成
     await db.insert(staffsTable).values({
       authUserId,
       firstName: "テスト",
@@ -52,44 +48,34 @@ const test = base.extend<{
     });
     cleanup.staffIds.push(staffId);
 
-    // Authユーザーを作成
-    const { data, error } = await supabase.auth.admin.createUser({
-      app_metadata: { role: "user", staffId },
+    const createResult = await authAdmin.createUser({
+      appMetadata: { role: "user", staffId },
       email,
-      email_confirm: true,
       id: authUserId,
       password,
     });
 
-    if (error) {
-      throw new Error(`テストユーザーの作成に失敗: ${error.message}`);
+    if (!createResult.success) {
+      throw new Error(`テストユーザーの作成に失敗: ${createResult.error}`);
     }
 
-    cleanup.authUserIds.push(data.user.id);
+    cleanup.authUserIds.push(createResult.data.id);
 
-    // createClient のモックを更新してこのユーザーを返す
-    const mockClient = {
-      auth: {
-        getUser: vi.fn().mockResolvedValue({
-          data: { user: { email, id: authUserId } },
-          error: null,
-        }),
-        signInWithPassword: vi
-          .fn()
-          .mockImplementation(async ({ password: inputPassword }) => {
-            // 正しいパスワードの場合は成功
-            if (inputPassword === password) {
-              return { data: {}, error: null };
-            }
-            return { data: null, error: { message: "Invalid credentials" } };
-          }),
-        updateUser: vi.fn().mockResolvedValue({ data: {}, error: null }),
-      },
-    };
-
-    vi.mocked(createClient).mockResolvedValue(mockClient as never);
+    vi.mocked(getAuth).mockResolvedValue({
+      verifyCurrentPassword: vi.fn(async (inputPassword: string) =>
+        inputPassword === password
+          ? { success: true, data: undefined }
+          : { success: false, error: AuthError.InvalidCredentials },
+      ),
+      updatePassword: vi.fn().mockResolvedValue({
+        success: true,
+        data: undefined,
+      }),
+    } as never);
 
     await use({ authUserId, email, password });
+
+    vi.mocked(getAuth).mockReset();
   },
 });
 
@@ -124,14 +110,11 @@ test("間違った現在のパスワードでエラーが返る", async ({
 });
 
 test("セッションが無効な場合エラーが返る", async () => {
-  // createClient のモックを更新してセッションなしを返す
-  vi.mocked(createClient).mockResolvedValue({
-    auth: {
-      getUser: vi.fn().mockResolvedValue({
-        data: { user: null },
-        error: null,
-      }),
-    },
+  vi.mocked(getAuth).mockResolvedValue({
+    verifyCurrentPassword: vi.fn().mockResolvedValue({
+      success: false,
+      error: AuthError.SessionExpired,
+    }),
   } as never);
 
   const result = await changePassword({
@@ -146,22 +129,15 @@ test("セッションが無効な場合エラーが返る", async () => {
 });
 
 test("パスワード更新に失敗した場合エラーが返る", async ({ testUser }) => {
-  // createClient のモックを更新してupdateUserでエラーを返す
-  vi.mocked(createClient).mockResolvedValue({
-    auth: {
-      getUser: vi.fn().mockResolvedValue({
-        data: { user: { email: testUser.email, id: testUser.authUserId } },
-        error: null,
-      }),
-      signInWithPassword: vi.fn().mockResolvedValue({
-        data: {},
-        error: null,
-      }),
-      updateUser: vi.fn().mockResolvedValue({
-        data: null,
-        error: { message: "Update failed" },
-      }),
-    },
+  vi.mocked(getAuth).mockResolvedValue({
+    verifyCurrentPassword: vi.fn().mockResolvedValue({
+      success: true,
+      data: undefined,
+    }),
+    updatePassword: vi.fn().mockResolvedValue({
+      success: false,
+      error: AuthError.UpdateFailed,
+    }),
   } as never);
 
   const result = await changePassword({

--- a/apps/web/features/auth/change-password/change-password.ts
+++ b/apps/web/features/auth/change-password/change-password.ts
@@ -1,5 +1,5 @@
 import { fail, type Result, succeed } from "@harusame0616/result";
-import { createClient } from "@repo/supabase/nextjs/server";
+import { AuthError, getAuth } from "@/features/auth/auth";
 
 const SessionError = "セッションが無効です。再度ログインしてください" as const;
 const CurrentPasswordError = "現在のパスワードが正しくありません" as const;
@@ -17,29 +17,18 @@ export async function changePassword({
   currentPassword: string;
   newPassword: string;
 }): Promise<Result<void, ChangePasswordError>> {
-  const supabase = await createClient();
+  const auth = await getAuth();
 
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user?.email) {
-    return fail(SessionError);
-  }
-
-  const { error: signInError } = await supabase.auth.signInWithPassword({
-    email: user.email,
-    password: currentPassword,
-  });
-
-  if (signInError) {
+  const verifyResult = await auth.verifyCurrentPassword(currentPassword);
+  if (!verifyResult.success) {
+    if (verifyResult.error === AuthError.SessionExpired) {
+      return fail(SessionError);
+    }
     return fail(CurrentPasswordError);
   }
 
-  const { error: updateError } = await supabase.auth.updateUser({
-    password: newPassword,
-  });
-
-  if (updateError) {
+  const updateResult = await auth.updatePassword(newPassword);
+  if (!updateResult.success) {
     return fail(UpdateError);
   }
 

--- a/apps/web/features/auth/get-user-role.ts
+++ b/apps/web/features/auth/get-user-role.ts
@@ -1,31 +1,15 @@
-import { createClient } from "@repo/supabase/nextjs/server";
+import { type AuthUser, getAuth } from "./auth";
 import { UserRole } from "./user/role";
 
 export { UserRole } from "./user/role";
 
 export async function getUserRole(): Promise<UserRole> {
-  const supabase = await createClient();
-
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const auth = await getAuth();
+  const user: AuthUser | null = await auth.getAuthUser();
 
   if (!user) {
     return UserRole.User;
   }
 
-  const role = user.app_metadata?.["role"] as string | undefined;
-
-  switch (role) {
-    case UserRole.Admin: {
-      return UserRole.Admin;
-    }
-    case UserRole.User:
-    case undefined: {
-      return UserRole.User;
-    }
-    default: {
-      throw new Error("不明なロールです。");
-    }
-  }
+  return user.role;
 }

--- a/apps/web/features/auth/get-user-staff-id.ts
+++ b/apps/web/features/auth/get-user-staff-id.ts
@@ -1,17 +1,8 @@
-import { createClient } from "@repo/supabase/nextjs/server";
+import { getAuth } from "./auth";
 
 export async function getUserStaffId(): Promise<string | null> {
-  const supabase = await createClient();
+  const auth = await getAuth();
+  const user = await auth.getAuthUser();
 
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) {
-    return null;
-  }
-
-  const staffId = user.app_metadata?.["staffId"] as string | undefined;
-
-  return staffId ?? null;
+  return user?.staffId ?? null;
 }

--- a/apps/web/features/auth/login/login.ts
+++ b/apps/web/features/auth/login/login.ts
@@ -1,5 +1,5 @@
 import { fail, type Result, succeed } from "@harusame0616/result";
-import { createClient } from "@repo/supabase/nextjs/server";
+import { getAuth } from "@/features/auth/auth";
 import type { LoginParams as LoginParameters } from "./schema";
 
 const LoginErrorMessage =
@@ -8,14 +8,13 @@ const LoginErrorMessage =
 export async function login(
   parameters: LoginParameters,
 ): Promise<Result<void, typeof LoginErrorMessage>> {
-  const supabase = await createClient();
-
-  const { error } = await supabase.auth.signInWithPassword({
+  const auth = await getAuth();
+  const result = await auth.signInWithPassword({
     email: parameters.username,
     password: parameters.password,
   });
 
-  if (error) {
+  if (!result.success) {
     return fail(LoginErrorMessage);
   }
 

--- a/apps/web/features/auth/logout/logout.ts
+++ b/apps/web/features/auth/logout/logout.ts
@@ -1,9 +1,9 @@
 import { type Success, succeed } from "@harusame0616/result";
-import { createClient } from "@repo/supabase/nextjs/server";
+import { getAuth } from "@/features/auth/auth";
 
 export async function logout(): Promise<Success<undefined>> {
-  const supabase = await createClient();
-  await supabase.auth.signOut();
+  const auth = await getAuth();
+  await auth.signOut();
 
   return succeed();
 }

--- a/apps/web/features/auth/supabase-auth-admin.ts
+++ b/apps/web/features/auth/supabase-auth-admin.ts
@@ -1,0 +1,73 @@
+import { fail, type Result, succeed } from "@harusame0616/result";
+import type { createAdminClient } from "@repo/supabase/admin";
+import type { AdminUser, AdminUserMetadata, AuthAdmin } from "./auth-admin";
+import { AuthError } from "./auth-error";
+
+type AdminSupabaseClient = ReturnType<typeof createAdminClient>;
+
+export class SupabaseAuthAdmin implements AuthAdmin {
+  constructor(private readonly supabase: AdminSupabaseClient) {}
+
+  async createUser(params: {
+    id?: string;
+    email: string;
+    password: string;
+    emailConfirm?: boolean;
+    appMetadata?: AdminUserMetadata;
+  }): Promise<Result<{ id: string }, AuthError>> {
+    const { data, error } = await this.supabase.auth.admin.createUser({
+      app_metadata: params.appMetadata,
+      email: params.email,
+      email_confirm: params.emailConfirm ?? true,
+      id: params.id,
+      password: params.password,
+    });
+
+    if (error) {
+      if (error.code === "email_exists") {
+        return fail(AuthError.EmailExists);
+      }
+      return fail(AuthError.CreateFailed);
+    }
+    return succeed({ id: data.user.id });
+  }
+
+  async updateUserById(
+    id: string,
+    params: {
+      email?: string;
+      appMetadata?: AdminUserMetadata;
+    },
+  ): Promise<Result<void, AuthError>> {
+    const { error } = await this.supabase.auth.admin.updateUserById(id, {
+      app_metadata: params.appMetadata,
+      email: params.email,
+    });
+    if (error) {
+      return fail(AuthError.UpdateFailed);
+    }
+    return succeed();
+  }
+
+  async deleteUser(id: string): Promise<Result<void, AuthError>> {
+    const { error } = await this.supabase.auth.admin.deleteUser(id);
+    if (error) {
+      return fail(AuthError.DeleteFailed);
+    }
+    return succeed();
+  }
+
+  async listUsers(): Promise<Result<AdminUser[], AuthError>> {
+    const { data, error } = await this.supabase.auth.admin.listUsers();
+    if (error) {
+      return fail(AuthError.ListFailed);
+    }
+    return succeed(
+      data.users.map((user) => ({
+        appMetadata: (user.app_metadata ?? {}) as AdminUserMetadata,
+        email: user.email,
+        id: user.id,
+      })),
+    );
+  }
+}

--- a/apps/web/features/auth/supabase-auth.ts
+++ b/apps/web/features/auth/supabase-auth.ts
@@ -1,0 +1,101 @@
+import { fail, type Result, succeed } from "@harusame0616/result";
+import type { createClient } from "@repo/supabase/nextjs/server";
+import type { Auth, AuthUser } from "./auth";
+import { AuthError } from "./auth-error";
+import { UserRole } from "./user/role";
+
+type SupabaseClient = Awaited<ReturnType<typeof createClient>>;
+
+interface AppMetadata {
+  role?: UserRole;
+  staffId?: string;
+}
+
+function toAuthUserRole(value: unknown): UserRole {
+  switch (value) {
+    case UserRole.Admin: {
+      return UserRole.Admin;
+    }
+    case UserRole.User:
+    case undefined: {
+      return UserRole.User;
+    }
+    default: {
+      throw new Error("不明なロールです。");
+    }
+  }
+}
+
+export class SupabaseAuth implements Auth {
+  constructor(private readonly supabase: SupabaseClient) {}
+
+  async signInWithPassword({
+    email,
+    password,
+  }: {
+    email: string;
+    password: string;
+  }): Promise<Result<void, AuthError>> {
+    const { error } = await this.supabase.auth.signInWithPassword({
+      email,
+      password,
+    });
+    if (error) {
+      return fail(AuthError.InvalidCredentials);
+    }
+    return succeed();
+  }
+
+  async signOut(): Promise<Result<void, AuthError>> {
+    const { error } = await this.supabase.auth.signOut();
+    if (error) {
+      return fail(AuthError.SignOutFailed);
+    }
+    return succeed();
+  }
+
+  async getAuthUser(): Promise<AuthUser | null> {
+    const {
+      data: { user },
+    } = await this.supabase.auth.getUser();
+    if (!user) {
+      return null;
+    }
+
+    const metadata = user.app_metadata as AppMetadata | undefined;
+    return {
+      role: toAuthUserRole(metadata?.role),
+      staffId: metadata?.staffId ?? null,
+    };
+  }
+
+  async verifyCurrentPassword(
+    currentPassword: string,
+  ): Promise<Result<void, AuthError>> {
+    const {
+      data: { user },
+    } = await this.supabase.auth.getUser();
+    if (!user?.email) {
+      return fail(AuthError.SessionExpired);
+    }
+
+    const { error } = await this.supabase.auth.signInWithPassword({
+      email: user.email,
+      password: currentPassword,
+    });
+    if (error) {
+      return fail(AuthError.InvalidCredentials);
+    }
+    return succeed();
+  }
+
+  async updatePassword(newPassword: string): Promise<Result<void, AuthError>> {
+    const { error } = await this.supabase.auth.updateUser({
+      password: newPassword,
+    });
+    if (error) {
+      return fail(AuthError.UpdateFailed);
+    }
+    return succeed();
+  }
+}

--- a/apps/web/features/auth/user/role.ts
+++ b/apps/web/features/auth/user/role.ts
@@ -2,5 +2,4 @@ export const UserRole = {
   Admin: "admin",
   User: "user",
 } as const;
-
 export type UserRole = (typeof UserRole)[keyof typeof UserRole];

--- a/apps/web/features/staff/delete/delete-staff.medium.server.test.ts
+++ b/apps/web/features/staff/delete/delete-staff.medium.server.test.ts
@@ -13,9 +13,14 @@ vi.mock("@repo/logger/nextjs/server", () => ({
   }),
 }));
 
-vi.mock("@repo/supabase/admin", () => ({
-  createAdminClient: vi.fn(),
-}));
+vi.mock("@/features/auth/auth-admin", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/features/auth/auth-admin")>();
+  return {
+    ...actual,
+    getAuthAdmin: vi.fn(),
+  };
+});
 
 const test = base.extend<{
   staff: {
@@ -29,7 +34,7 @@ const test = base.extend<{
     lastName: string;
     staffId: string;
   };
-  supabaseAdminMock: Mock;
+  authAdminMock: Mock;
 }>({
   async staff({}, use) {
     const staff = {
@@ -55,9 +60,9 @@ const test = base.extend<{
     await use(staff);
     await db.delete(staffsTable).where(eq(staffsTable.staffId, staff.staffId));
   },
-  async supabaseAdminMock({}, use: any) {
-    const supabaseModule = await import("@repo/supabase/admin");
-    const mock = vi.mocked(supabaseModule.createAdminClient);
+  async authAdminMock({}, use) {
+    const authAdminModule = await import("@/features/auth/auth-admin");
+    const mock = vi.mocked(authAdminModule.getAuthAdmin);
     await use(mock);
     vi.clearAllMocks();
   },
@@ -92,16 +97,15 @@ test("自分自身を削除しようとした場合にエラーが返される",
 
 test("存在するスタッフを削除できる", async ({
   staffWithAuthUser,
-  supabaseAdminMock,
+  authAdminMock,
 }) => {
   const currentUserStaffId = "00000000-0000-0000-0000-000000000001";
 
-  supabaseAdminMock.mockReturnValue({
-    auth: {
-      admin: {
-        deleteUser: vi.fn().mockResolvedValue({ error: null }),
-      },
-    },
+  authAdminMock.mockReturnValue({
+    createUser: vi.fn(),
+    deleteUser: vi.fn().mockResolvedValue({ success: true, data: undefined }),
+    listUsers: vi.fn(),
+    updateUserById: vi.fn(),
   });
 
   const result = await deleteStaff({

--- a/apps/web/features/staff/delete/delete-staff.ts
+++ b/apps/web/features/staff/delete/delete-staff.ts
@@ -1,8 +1,8 @@
 import { fail, type Result, succeed } from "@harusame0616/result";
-import { createAdminClient } from "@repo/supabase/admin";
 import { db } from "@workspace/db/client";
 import { staffsTable } from "@workspace/db/schema/staff";
 import { eq } from "drizzle-orm";
+import { getAuthAdmin } from "@/features/auth/auth-admin";
 
 const STAFF_NOT_FOUND_ERROR_MESSAGE =
   "指定されたスタッフが見つかりません" as const;
@@ -38,7 +38,7 @@ export async function deleteStaff({
     return fail(STAFF_NOT_FOUND_ERROR_MESSAGE);
   }
 
-  const supabase = createAdminClient();
+  const authAdmin = getAuthAdmin();
 
   await db.transaction(async (tx) => {
     await tx.delete(staffsTable).where(eq(staffsTable.staffId, staffId));
@@ -47,12 +47,12 @@ export async function deleteStaff({
       return;
     }
 
-    const { error: deleteError } = await supabase.auth.admin.deleteUser(
-      staff.authUserId,
-    );
+    const deleteResult = await authAdmin.deleteUser(staff.authUserId);
 
-    if (deleteError) {
-      throw deleteError;
+    if (!deleteResult.success) {
+      throw new Error(
+        `認証ユーザーの削除に失敗しました: ${deleteResult.error}`,
+      );
     }
   });
 

--- a/apps/web/features/staff/edit/edit-staff.ts
+++ b/apps/web/features/staff/edit/edit-staff.ts
@@ -1,10 +1,10 @@
 import { fail, type Result, succeed } from "@harusame0616/result";
 import { getLogger } from "@repo/logger/nextjs/server";
-import { createAdminClient } from "@repo/supabase/admin";
 import { db } from "@workspace/db/client";
 import { staffsTable } from "@workspace/db/schema/staff";
 import { eq } from "drizzle-orm";
 import { authUsers } from "drizzle-orm/supabase";
+import { getAuthAdmin } from "@/features/auth/auth-admin";
 import type { EditStaffParams as EditStaffParameters } from "./schema";
 
 const STAFF_NOT_FOUND_ERROR_MESSAGE =
@@ -58,21 +58,18 @@ export async function editStaff(
         .where(eq(authUsers.id, authUserId));
     });
     if (originalRole !== role) {
-      const supabase = createAdminClient();
-      const { error: updateError } = await supabase.auth.admin.updateUserById(
-        authUserId,
-        {
-          app_metadata: {
-            role,
-            staffId,
-          },
+      const authAdmin = getAuthAdmin();
+      const updateResult = await authAdmin.updateUserById(authUserId, {
+        appMetadata: {
+          role,
+          staffId,
         },
-      );
+      });
 
-      if (updateError) {
+      if (!updateResult.success) {
         logger.error("ロールの更新に失敗", {
           authUserId,
-          error: updateError.message,
+          error: updateResult.error,
         });
         throw new Error(UPDATE_AUTH_ERROR_MESSAGE);
       }

--- a/apps/web/features/staff/register/register-staff.medium.server.test.ts
+++ b/apps/web/features/staff/register/register-staff.medium.server.test.ts
@@ -1,9 +1,9 @@
 import { randomUUID } from "node:crypto";
-import { createAdminClient } from "@repo/supabase/admin";
 import { db } from "@workspace/db/client";
 import { staffsTable } from "@workspace/db/schema/staff";
 import { eq } from "drizzle-orm";
 import { test as base, expect } from "vitest";
+import { getAuthAdmin } from "@/features/auth/auth-admin";
 import { registerStaff } from "./register-staff";
 
 const test = base.extend<{
@@ -14,7 +14,7 @@ const test = base.extend<{
     const authUserIds: string[] = [];
     await use({ authUserIds, staffIds });
 
-    const supabase = createAdminClient();
+    const authAdmin = getAuthAdmin();
     for (const staffId of staffIds) {
       const [staff] = await db
         .select({ authUserId: staffsTable.authUserId })
@@ -25,11 +25,11 @@ const test = base.extend<{
       await db.delete(staffsTable).where(eq(staffsTable.staffId, staffId));
 
       if (staff?.authUserId) {
-        await supabase.auth.admin.deleteUser(staff.authUserId);
+        await authAdmin.deleteUser(staff.authUserId);
       }
     }
     for (const authUserId of authUserIds) {
-      await supabase.auth.admin.deleteUser(authUserId);
+      await authAdmin.deleteUser(authUserId);
     }
   },
 });
@@ -64,12 +64,14 @@ test("スタッフを正常に登録できる", async ({ cleanup }) => {
   expect(staffs[0]?.firstName).toBe(input.firstName);
   expect(staffs[0]?.lastName).toBe(input.lastName);
 
-  const supabase = createAdminClient();
-  const { data } = await supabase.auth.admin.listUsers();
-  const user = data.users.find((u) => u.email === input.email);
+  const authAdmin = getAuthAdmin();
+  const listResult = await authAdmin.listUsers();
+  expect(listResult.success).toBe(true);
+  if (!listResult.success) return;
+  const user = listResult.data.find((u) => u.email === input.email);
   expect(user).toBeDefined();
-  expect(user?.app_metadata?.["role"]).toBe(input.role);
-  expect(user?.app_metadata?.["staffId"]).toBe(result.data.staffId);
+  expect(user?.appMetadata.role).toBe(input.role);
+  expect(user?.appMetadata.staffId).toBe(result.data.staffId);
 });
 
 test("firstName と lastName が24文字（境界値）で登録できる", async ({
@@ -121,10 +123,12 @@ test("管理者ロールで登録できる", async ({ cleanup }) => {
     cleanup.staffIds.push(result.data.staffId);
   }
 
-  const supabase = createAdminClient();
-  const { data } = await supabase.auth.admin.listUsers();
-  const user = data.users.find((u) => u.email === input.email);
-  expect(user?.app_metadata?.["role"]).toBe("admin");
+  const authAdmin = getAuthAdmin();
+  const listResult = await authAdmin.listUsers();
+  expect(listResult.success).toBe(true);
+  if (!listResult.success) return;
+  const user = listResult.data.find((u) => u.email === input.email);
+  expect(user?.appMetadata.role).toBe("admin");
 });
 
 test("Supabase Auth に既に存在するメールアドレスで登録するとエラーになる", async ({
@@ -133,14 +137,14 @@ test("Supabase Auth に既に存在するメールアドレスで登録すると
   const uniqueId = randomUUID().slice(0, 8);
   const email = `staff-dup-${uniqueId}@example.com`;
 
-  const supabase = createAdminClient();
-  const { data: existingUser } = await supabase.auth.admin.createUser({
+  const authAdmin = getAuthAdmin();
+  const existingUserResult = await authAdmin.createUser({
     email,
-    email_confirm: true,
     password: "TestPassword123!",
   });
-  if (existingUser.user) {
-    cleanup.authUserIds.push(existingUser.user.id);
+  expect(existingUserResult.success).toBe(true);
+  if (existingUserResult.success) {
+    cleanup.authUserIds.push(existingUserResult.data.id);
   }
 
   const input = {

--- a/apps/web/features/staff/register/register-staff.ts
+++ b/apps/web/features/staff/register/register-staff.ts
@@ -1,8 +1,9 @@
 import { type Result, succeed, tryCatchAsync } from "@harusame0616/result";
-import { createAdminClient } from "@repo/supabase/admin";
 import { db } from "@workspace/db/client";
 import { staffsTable } from "@workspace/db/schema/staff";
 import { v7 as uuidv7 } from "uuid";
+import { getAuthAdmin } from "@/features/auth/auth-admin";
+import { AuthError } from "@/features/auth/auth-error";
 import type { RegisterStaffParams as RegisterStaffParameters } from "./schema";
 
 const EMAIL_EXISTS_ERROR = "このメールアドレスは既に登録されています" as const;
@@ -19,7 +20,7 @@ export async function registerStaff({
 }: RegisterStaffParameters): Promise<
   Result<{ staffId: string }, ErrorMessage>
 > {
-  const supabase = createAdminClient();
+  const authAdmin = getAuthAdmin();
   const staffId = uuidv7();
   const authUserId = uuidv7();
 
@@ -29,19 +30,17 @@ export async function registerStaff({
         .insert(staffsTable)
         .values({ authUserId, firstName, lastName, staffId });
 
-      const { error } = await supabase.auth.admin.createUser({
-        app_metadata: { role, staffId },
+      const result = await authAdmin.createUser({
+        appMetadata: { role, staffId },
         email,
-        email_confirm: true,
         id: authUserId,
         password,
       });
 
-      if (error) {
-        if (error.code === "email_exists") {
+      if (!result.success) {
+        if (result.error === AuthError.EmailExists) {
           throw EMAIL_EXISTS_ERROR;
         }
-
         throw CREATE_AUTH_ERROR;
       }
 


### PR DESCRIPTION
## 概要

apps/web から `supabase.auth.*` への直接依存を排除し、`getAuth()` / `getAuthAdmin()` ファクトリ関数経由で利用するよう抽象化した。supabase-js の破壊的変更検知のため AuthAdmin の medium テストも追加。

## やったこと

- `apps/web/features/auth/auth.ts` を新設し、`signInWithPassword` / `signOut` / `getAuthUser` / `verifyCurrentPassword` などをラップする `Auth` クラスと `getAuth()` ファクトリを提供
- `apps/web/features/auth/auth-admin.ts` を新設し、`createUser` / `updateUserById` / `deleteUser` / `listUsers` をラップする `AuthAdmin` クラスと `getAuthAdmin()` ファクトリを提供
- `apps/web/features/auth/auth-error.ts` を新設し、`AuthError`（InvalidCredentials / EmailExists / CreateFailed / UpdateFailed / DeleteFailed / SignOutFailed / ListFailed / SessionExpired / Unknown）を定数オブジェクトとして集約
- `get-user-role` / `get-user-staff-id` / `login` / `logout` / `change-password` / `staff/register` / `staff/edit` / `staff/delete` / `customer-notes/.../advice/route` から `createClient` / `createAdminClient` の直接呼び出しを削除し、`getAuth()` / `getAuthAdmin()` 経由に置き換え
- `app_metadata` のキャストや `role` のスイッチ判定など、これまで呼び出し側に散在していたロジックを `Auth` 内 (`toAuthUserRole`) に集約
- `auth-admin.medium.server.test.ts` を新規追加し、依存ライブラリ（supabase-js）更新時の破壊的変更を medium テストで検知できるようにした
- 既存の `change-password` / `register-staff` の medium テストを新ラッパー前提に書き換え
- `e2e/staffs.e2e.test.ts` を新インターフェースに追随

## 補足

- Server Action / Server Component 側の責務は変わらず、ラッパー導入によるロジック移動が中心のリファクタリング。
- `AuthError` は文字列 const オブジェクト + 型として表現しており、`Result<T, AuthError>` で呼び出し側が網羅的に分岐できる構造。
- 直接 `supabase.auth.*` を呼んでいる箇所が他にあれば、本 PR では対象外（grep 上は apps/web からの直接依存はゼロを確認）。

## 参考

- ClickUp: https://app.clickup.com/t/86expf865