### PR TITLE
ClickUp チケット操作スキルを追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -339,7 +339,8 @@
         "www.json-schema.org",
         "json.schemastore.org",
         "www.schemastore.org",
-        "*.modelcontextprotocol.io"
+        "*.modelcontextprotocol.io",
+        "*.api.clickup.com"
       ],
       "allowLocalBinding": true
     }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -340,7 +340,7 @@
         "json.schemastore.org",
         "www.schemastore.org",
         "*.modelcontextprotocol.io",
-        "*.api.clickup.com"
+        "api.clickup.com"
       ],
       "allowLocalBinding": true
     }

--- a/.claude/skills/ticket/SKILL.md
+++ b/.claude/skills/ticket/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: ticket
+description: ClickUp チケットの取得・作成・更新を行う。チケット操作（表示・作成・更新）が要求された時に必ず使用する。引数としてチケット ID を受け取る。省略時は現在のブランチ名から自動抽出する。
+allowed-tools: Bash(curl:*), Bash(git:*)
+argument-hint: "[ticket-id]"
+---
+
+# ClickUp チケット管理
+
+## チケット ID の解決
+
+1. 引数でチケット ID が指定された場合はそれを使用する
+2. 引数がない場合は以下で現在のブランチ名からチケット ID を抽出する:
+
+   ```bash
+   git branch --show-current
+   ```
+
+   - 抽出ルール: ブランチ名から `CU-` などのプレフィックスを除いた後、`__` または `-` より前の部分をチケット ID とする
+     - 例: `CU-86excqgpj__nemoto-masaharu` → `86excqgpj`
+     - 例: `86excqgpj-fix-bug` → `86excqgpj`
+   - 抽出できない場合はユーザーにチケット ID の指定を促してスキルを終了する
+
+## 認証
+
+- `CLICKUP_API_KEY` 環境変数を使用する
+- 値の確認・表示・ログ出力は絶対に行わない
+- 認証エラー（401）が返ってきた場合は `~/.claude/settings.json` の `env` に `CLICKUP_API_KEY` が正しく設定されているかユーザーに確認を促す
+
+## API 設定
+
+- ベース URL: `https://api.clickup.com/api/v2`
+- リスト ID: `901818299466`
+- チケット取得時は必ず `include_markdown_description=true` を付与する
+
+---
+
+## チケット操作
+
+ - 取得: `markdown_description` を整形してユーザーに提示する
+ - 作成: リスト ID `901817311656` に作成する
+ - 更新: description の更新は必ず `markdown_description` フィールドを使用する
+
+---
+
+## チケット説明テンプレート
+
+チケットの説明（作成・更新時）は以下のテンプレートに従う。各セクションは必ず用意し、記載内容がない場合は「なし」と記載する。


### PR DESCRIPTION
## Summary
- ClickUp API でチケットの取得・作成・更新を行う `ticket` スキルを追加
- `.claude/settings.json` の `allowedHosts` に `*.api.clickup.com` を追加

## Test plan
- [ ] `/ticket <id>` でチケット取得ができることを確認
- [ ] 引数なしでブランチ名からチケット ID を抽出できることを確認