### PR TITLE
fix: allowBuilds を全パッケージ禁止に統一し削除済み設定 onlyBuiltDependencies を撤去

### DIFF
--- a/agent-docs/パッケージ管理のガイドライン.md
+++ b/agent-docs/パッケージ管理のガイドライン.md
@@ -202,13 +202,15 @@ catalogMode: strict
 
 #### pnpm
 
-pnpm 10 以降は依存パッケージのライフサイクルスクリプトをデフォルトで実行しないため、追加の設定は不要。
+pnpm 10 以降は依存パッケージのライフサイクルスクリプトをデフォルトで実行しない。さらに `strictDepBuilds` がデフォルトで有効なため、ビルドスクリプトを持つパッケージが未レビューのまま残っていると、インストールが `ERR_PNPM_IGNORED_BUILDS` でエラー終了する。
 
-加えて、`pnpm-workspace.yaml` で `allowBuilds` を `false` に設定し、ビルドスクリプトの実行を明示的に禁止する。
+ビルドスクリプトを持つパッケージは、レビューを経たうえで `pnpm-workspace.yaml` の `allowBuilds` に実行可否を明示的に列挙する。`allowBuilds` はパッケージ名をキーとするマップで、`false`（レビュー済み・実行禁止）または `true`（レビュー済み・実行許可）を指定する。
 
 ```yaml
 # pnpm-workspace.yaml
-allowBuilds: false
+allowBuilds:
+  sharp: false # レビュー済み・実行禁止
+  esbuild: true # レビュー済み・実行許可
 ```
 
-どうしても実行が必要なパッケージがある場合は、`onlyBuiltDependencies` に個別に列挙してレビューを経たうえで許可する。
+どうしても実行が必要なパッケージのみ、レビューを経たうえで `true` を指定して許可する。

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,12 +2,15 @@ packages:
   - apps/*
   - packages/*
 
+# 依存パッケージのビルドスクリプト (preinstall / postinstall 等) はデフォルト実行禁止。
+# ビルドスクリプトを持つパッケージはレビューのうえ false (禁止) / true (許可) を明示的に列挙する
+# (未列挙のままだとインストールが ERR_PNPM_IGNORED_BUILDS でエラーになる)
 allowBuilds:
   esbuild: false
   msw: false
   sharp: false
   supabase: false
-  unrs-resolver: true
+  unrs-resolver: false
 
 catalog:
   react: 19.2.5
@@ -87,8 +90,3 @@ catalog:
   prettier-plugin-toml: 2.0.6
 
 catalogMode: strict
-
-onlyBuiltDependencies:
-  - supabase
-  - sharp
-  - unrs-resolver


### PR DESCRIPTION
## 概要

`pnpm-workspace.yaml` のビルドスクリプト関連設定を整理します。

## 背景

jukubox / harusame.dev の allowBuilds 調査（harusame-dev/jukubox#163、harusame-dev/harusame.dev#179、ポリシー文書: harusame-dev/development-policy#2）の流れで本リポジトリを確認したところ、以下の状態でした。

- `onlyBuiltDependencies` は **pnpm 11 で削除され `allowBuilds` に統合済み**の設定（本リポジトリは pnpm@11.1.2）のため、無視される死に設定として残存
- 旧設定（supabase / sharp / unrs-resolver を許可）と現行有効な `allowBuilds`（unrs-resolver のみ許可）の内容が矛盾

## 変更内容

- `onlyBuiltDependencies` ブロックを削除
- `allowBuilds` を**全パッケージ禁止（false）**に統一（unrs-resolver を true → false へ変更）
- 運用ルールのコメントを追記

## 検証

- [x] node_modules 削除状態からの `pnpm install --frozen-lockfile` が成功（ERR_PNPM_IGNORED_BUILDS なし）
- [x] 唯一の挙動変更である unrs-resolver は、ビルド済みプラットフォームバイナリ（@unrs/resolver-binding-*）経由でロードできることを確認（postinstall 不要）
- supabase の bin 警告（バイナリ未ダウンロード）は main でも `allowBuilds: supabase: false` が有効だったため既存挙動で、本 PR による変化はなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)