### PR TITLE
fix(claude): ClickUp チケット説明の 2000 文字打ち切りを廃止

### DIFF
--- a/.claude/hooks/clickup-branch-context.ts
+++ b/.claude/hooks/clickup-branch-context.ts
@@ -55,7 +55,7 @@ console.log(
         `URL: ${task.url ?? ""}`,
         "",
         "説明:",
-        (task.description ?? "").slice(0, 2000),
+        task.description ?? "",
       ].join("\n"),
     },
   }),


### PR DESCRIPTION
## 概要

SessionStart フックが注入する ClickUp チケット説明の 2000 文字打ち切りを廃止し、全文を注入する。

## 背景

`.claude/hooks/clickup-branch-context.ts` は bash 版から移植した際に `head -c 2000` 相当の `slice(0, 2000)` を引き継いでいた。説明が途中で切れると前提条件や受入条件を読み落とすため削除する。

## 変更内容

```diff
-        (task.description ?? "").slice(0, 2000),
+        task.description ?? "",
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MWj1ndYBRn9pEWBrsxLMBa